### PR TITLE
import sys for access to sys.exit() on line 14

### DIFF
--- a/lib/utils/validator.py
+++ b/lib/utils/validator.py
@@ -1,3 +1,4 @@
+import sys
 from urllib.parse import urlparse
 
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/shenril/Sitadel on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/utils/validator.py:13:9: F821 undefined name 'sys'
        sys.exit(2)
        ^
1     F821 undefined name 'sys'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree