### PR TITLE
#8 Add tests for attack and fingerprint modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 test: clean
+	@python -m pytest tests -m "not dangerous"
+
+full_test: clean
 	@python -m pytest tests
 
 clean:

--- a/tests/lib/config/test_attack_config.yml
+++ b/tests/lib/config/test_attack_config.yml
@@ -1,0 +1,18 @@
+## Risk level allowed for the scan
+## Most attacks plugin are registered as noisy
+## Values are:
+##             - 0 : NO DANGER
+##             - 1 : NOISY
+##             - 2 : DANGEROUS
+risk: 1
+
+## DNS Server used to perform CDN verification
+## Default is Google DNS
+dns_resolver: 8.8.8.8
+
+## Root location for the datafile used by the plugins
+datastore: lib/data
+    
+## List of attacks plugins activated
+attack_plugins:
+    - bruteforce

--- a/tests/lib/config/test_fingerprint_config.yml
+++ b/tests/lib/config/test_fingerprint_config.yml
@@ -1,0 +1,22 @@
+## Risk level allowed for the scan
+## Most attacks plugin are registered as noisy
+## Values are:
+##             - 0 : NO DANGER
+##             - 1 : NOISY
+##             - 2 : DANGEROUS
+risk: 1
+
+## DNS Server used to perform CDN verification
+## Default is Google DNS
+dns_resolver: 8.8.8.8
+    
+## List of fingerprint plugins activated
+fingerprint_plugins:
+    - cms
+    - system
+    - framework
+    - frontend
+    - header
+    - lang
+    - server
+    - waf

--- a/tests/lib/modules/attacks/test_attack.py
+++ b/tests/lib/modules/attacks/test_attack.py
@@ -1,10 +1,13 @@
 import pytest
+import logging
 
 from lib.config import settings
 from lib.config.settings import Risk
 from lib.modules.attacks import AttackPlugin, Attacks
 from lib.utils.container import Services
 from lib.utils.output import Output
+from lib.utils.datastore import Datastore
+from lib.request.request import Request
 
 
 def test_attack_plugin():
@@ -52,3 +55,14 @@ def test_attack_launcher():
 
     f = Attacks(None, None)
     assert hasattr(f, 'run')
+
+@pytest.mark.dangerous
+def test_current_plugins():
+    test_url="http://example.com"
+    settings.from_yaml("tests/lib/config/test_attack_config.yml")
+    Services.register("datastore", Datastore(settings.datastore))
+    Services.register("logger", logging.getLogger("sitadelLog"))
+    Services.register("output", Output())
+    Services.register("request_factory",Request(url=test_url, agent="Sitadel"))
+    plugins = settings.attack_plugins
+    Attacks(test_url, None).run(plugins)

--- a/tests/lib/modules/fingerprints/test_fingerprint.py
+++ b/tests/lib/modules/fingerprints/test_fingerprint.py
@@ -1,8 +1,13 @@
 import pytest
+import logging
 
 from lib.config import settings
 from lib.config.settings import Risk
 from lib.modules.fingerprints import FingerprintPlugin, Fingerprints
+from lib.utils.container import Services
+from lib.utils.output import Output
+from lib.utils.datastore import Datastore
+from lib.request.request import Request
 
 
 def test_fingerprint_plugin():
@@ -47,3 +52,13 @@ def test_new_fingerprint_plugin():
 def test_fingerprint_launcher():
     f = Fingerprints(None, None, None, None, None, None)
     assert hasattr(f, 'run')
+
+@pytest.mark.dangerous
+def test_current_plugins():
+    test_url="http://example.com"
+    settings.from_yaml("tests/lib/config/test_fingerprint_config.yml")
+    Services.register("logger", logging.getLogger("sitadelLog"))
+    Services.register("output", Output())
+    Services.register("request_factory",Request(url=test_url, agent="Sitadel"))
+    plugins = settings.fingerprint_plugins
+    Fingerprints(agent="Sitadel",proxy=None,redirect=None,timeout=None,url=test_url,cookie=None).run(plugins)


### PR DESCRIPTION
This is not optimal but for now it tests all the current plugins against example.com to make sure no warnings or error comes out

Ideally each plugins should be tested against mocked response ... 