### PR TITLE
#23 handle deprecation of default method

### DIFF
--- a/lib/config/settings.py
+++ b/lib/config/settings.py
@@ -45,7 +45,7 @@ class Settings(object):
         with open(filepath, 'r') as yamlfile:
             try:
                 # Getting config from the file
-                config = yaml.load(yamlfile)
+                config = yaml.load(yamlfile, Loader=yaml.SafeLoader)
                 # Merging the dictionaries and getting result
                 cls.cfg = {**cls.cfg, **config}
             except yaml.YAMLError as e:


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Looking at this and considering the fact that we don't do anything exotic, we'll go with the SafeLoader