### PR TITLE
Fix injection modules building malformed attack URLs (#50)

### DIFF
--- a/lib/modules/attacks/__init__.py
+++ b/lib/modules/attacks/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import pkgutil
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from lib.config.settings import Risk
 from lib.utils.container import Services
@@ -10,6 +11,24 @@ from .. import IPlugin
 class AttackPlugin(metaclass=IPlugin):
     # Default risk level for attack modules is NOISY since it sends requests
     level = Risk.NOISY
+
+    @staticmethod
+    def taint_url(url, payload):
+        """Rebuild ``url`` with every query parameter value replaced by ``payload``.
+
+        Returns the tainted URL, or ``None`` when the URL has no query
+        parameters to inject into. The query string is reassembled with
+        ``urlunsplit`` so the separators (``?`` and ``&``) are preserved,
+        instead of blindly concatenating onto the original URL.
+        """
+        parts = urlsplit(url)
+        params = dict(parse_qsl(parts.query))
+        if not params:
+            return None
+        tainted = {name: payload for name in params}
+        return urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, urlencode(tainted), parts.fragment)
+        )
 
     def process(self, start_url, crawled_urls):
         raise NotImplementedError(str(self) + ": Process method not found")

--- a/lib/modules/attacks/injection/html.py
+++ b/lib/modules/attacks/injection/html.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from .. import AttackPlugin
@@ -12,20 +11,16 @@ class Html(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None
                 )
                 if resp.status_code == 200:
-                    if re.search(payload, resp.text):
+                    # Match the injected HTML literally, not as a regex
+                    if re.search(re.escape(payload), resp.text):
                         self.output.finding(
                             "That site is may be vulnerable to HTML Code Injection at %s\nInjection: %s"
                             % (url, payload)

--- a/lib/modules/attacks/injection/ldap.py
+++ b/lib/modules/attacks/injection/ldap.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from lib.config.settings import Risk
@@ -42,14 +41,9 @@ class LDAP(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None

--- a/lib/modules/attacks/injection/php.py
+++ b/lib/modules/attacks/injection/php.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from .. import AttackPlugin
@@ -12,14 +11,9 @@ class Php(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None

--- a/lib/modules/attacks/injection/rfi.py
+++ b/lib/modules/attacks/injection/rfi.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from lib.config.settings import Risk
@@ -16,14 +15,9 @@ class Rfi(AttackPlugin):
     def attack(self, payload, url):
         flag = r"root:/root:/bin/bash|default=multi([0])disk([0])rdisk([0])partition([1])\\WINDOWS"
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None
@@ -42,7 +36,7 @@ class Rfi(AttackPlugin):
     def process(self, start_url, crawled_urls):
         self.output.info("Checking remote file inclusion...")
         db = self.datastore.open("rfi.txt", "r")
-        dbfiles = [x.split("\n") for x in db]
+        dbfiles = [x.rstrip("\n") for x in db]
         for payload in dbfiles:
             with ThreadPoolExecutor(max_workers=None) as executor:
                 futures = [

--- a/lib/modules/attacks/injection/sql.py
+++ b/lib/modules/attacks/injection/sql.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from lib.config.settings import Risk
@@ -54,14 +53,9 @@ class Sql(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None
@@ -81,7 +75,7 @@ class Sql(AttackPlugin):
     def process(self, start_url, crawled_urls):
         self.output.info("Checking sql injection...")
         db = self.datastore.open("sql.txt", "r")
-        dbfiles = [x.split("\n") for x in db]
+        dbfiles = [x.rstrip("\n") for x in db]
         for payload in dbfiles:
             with ThreadPoolExecutor(max_workers=None) as executor:
                 futures = [

--- a/lib/modules/attacks/injection/xpath.py
+++ b/lib/modules/attacks/injection/xpath.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from .. import AttackPlugin
@@ -13,14 +12,9 @@ class Xpath(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None
@@ -39,7 +33,7 @@ class Xpath(AttackPlugin):
     def process(self, start_url, crawled_urls):
         self.output.info("Checking xpath injection...")
         db = self.datastore.open("xpath.txt", "r")
-        dbfiles = [x.split("\n") for x in db]
+        dbfiles = [x.rstrip("\n") for x in db]
         for payload in dbfiles:
             with ThreadPoolExecutor(max_workers=None) as executor:
                 futures = [

--- a/lib/modules/attacks/injection/xss.py
+++ b/lib/modules/attacks/injection/xss.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import parse_qsl, urlencode, urlsplit
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from lib.utils.container import Services
 from .. import AttackPlugin
@@ -13,23 +12,19 @@ class Xss(AttackPlugin):
 
     def attack(self, payload, url):
         try:
-            # Current request parameters
-            params = dict(parse_qsl(urlsplit(url).query))
-            # Change the value of the parameters with the payload
-            tainted_params = {x: payload for x in params}
-
-            if len(tainted_params) > 0:
-                # Prepare the attack URL
-                attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
+            # Rebuild the URL with the payload injected in every parameter
+            attack_url = self.taint_url(url, payload)
+            if attack_url is not None:
                 self.output.debug("Testing: %s" % attack_url)
                 resp = self.request.send(
                     url=attack_url, method="GET", payload=None, headers=None
                 )
                 if resp.status_code == 200:
-                    if re.search(payload[0], resp.text, re.I):
+                    # Match the payload literally: it is HTML, not a regex
+                    if re.search(re.escape(payload), resp.text, re.I):
                         self.output.finding(
                             "That site may be vulnerable to Cross Site Scripting (XSS) at %s \nInjection: %s"
-                            % (url, payload[0])
+                            % (url, payload)
                         )
         except Exception as e:
             self.logger.error(e)
@@ -39,7 +34,7 @@ class Xss(AttackPlugin):
 
     def process(self, start_url, crawled_urls):
         db = self.datastore.open("xss.txt", "r")
-        dbfiles = [x.split("\n") for x in db]
+        dbfiles = [x.rstrip("\n") for x in db]
         self.output.info("Checking cross site scripting...")
         for payload in dbfiles:
             with ThreadPoolExecutor(max_workers=None) as executor:

--- a/tests/lib/modules/attacks/test_attack.py
+++ b/tests/lib/modules/attacks/test_attack.py
@@ -59,6 +59,28 @@ def test_new_attack_plugin():
         raise AssertionError
 
 
+def test_taint_url():
+    from urllib.parse import parse_qsl, urlsplit
+
+    payload = "1' OR '1'='1"
+
+    # Every query parameter value is replaced by the payload, with proper
+    # separators, and the original path/fragment are preserved.
+    tainted = AttackPlugin.taint_url("http://host/path?id=1&q=2#frag", payload)
+    parts = urlsplit(tainted)
+    if parts.path != "/path" or parts.fragment != "frag":
+        raise AssertionError
+    values = dict(parse_qsl(parts.query))
+    if set(values.keys()) != {"id", "q"}:
+        raise AssertionError
+    if any(v != payload for v in values.values()):
+        raise AssertionError
+
+    # URLs without a query string yield nothing to inject into.
+    if AttackPlugin.taint_url("http://host/path", payload) is not None:
+        raise AssertionError
+
+
 def test_attack_launcher():
     # Add services container for running
     Services.register("output", Output())


### PR DESCRIPTION
Fixes #50.

## Problem
The injection modules built the attack URL as:
```python
attack_url = urlsplit(url).geturl() + urlencode(tainted_params)
```
`urlsplit(url).geturl()` returns the **entire** URL including its existing query string, and the encoded params were concatenated with **no `?`/`&` separator** — `http://x/p?id=1` + `id=PAYLOAD` → `http://x/p?id=1id=PAYLOAD`. The payload never became its own parameter, so the injection modules effectively never injected.

Two more compounding bugs:
- `dbfiles = [x.split("\n") for x in db]` made each payload a **list**, not a string, so `urlencode` emitted a Python list repr.
- XSS/HTML matched the reflected payload by using the payload itself as a **regex** (`re.search(payload, ...)`), which breaks on metacharacters like `(`, `[`.

## Fix
- New shared helper `AttackPlugin.taint_url(url, payload)` rebuilds the query with `urlunsplit`, preserving separators, path and fragment, and returns `None` when there is nothing to inject into. All 7 injection modules now use it, removing the duplicated broken logic.
- Wordlists are read as strings (`x.rstrip("\n")`).
- Reflected XSS/HTML payloads are matched literally via `re.escape`.
- Added a unit test for `taint_url`.

## Verification
- `make test` (pytest `-m "not dangerous"`): **18 passed**.
- `make criticalint` (flake8 E901,E999,F821,F822,F823): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)