### PR TITLE
Handle request errors gracefully instead of crashing the scan (#51)

### DIFF
--- a/lib/modules/fingerprints/__init__.py
+++ b/lib/modules/fingerprints/__init__.py
@@ -48,6 +48,14 @@ class Fingerprints:
                 cookies=self.cookie,
             )
 
+            # The request layer returns None when the target could not be
+            # reached; abort the fingerprint phase cleanly instead of crashing.
+            if resp is None:
+                self.output.error(
+                    "No response from the target\nAborting fingerprint...\n"
+                )
+                return
+
             # Pass the result over the fingerprint module for processing
             fingerprints = [
                 (p(), p().process(resp.headers, resp.text))

--- a/lib/request/request.py
+++ b/lib/request/request.py
@@ -1,7 +1,7 @@
 import sys
 
 from requests import Request, Session
-from requests import RequestException
+from requests import ConnectionError, RequestException, Timeout
 import urllib3
 
 from . import ragent as ragent
@@ -35,11 +35,17 @@ class SingleRequest:
                 allow_redirects=self.redirect,
                 verify=False)
             return resp
-        except TimeoutError:
+        except Timeout:
+            # requests raises requests.exceptions.Timeout (a RequestException),
+            # not the builtin TimeoutError, so it must be caught explicitly.
             output.error("Timeout error on the URL: %s" % url)
+        except ConnectionError as err:
+            output.error("Connection error on the URL: %s\n {0}\n".format(err) % url)
         except RequestException as err:
             output.error("Error while trying to contact the website: \n {0}\n".format(err))
-            raise(err)
+        # On any handled error return None so callers can degrade gracefully
+        # (a single failing request must never abort the whole scan).
+        return None
 
     def prepare_request(self, url, method, payload, headers, cookies):
         if payload is None:

--- a/tests/lib/request/test_request.py
+++ b/tests/lib/request/test_request.py
@@ -39,3 +39,12 @@ def test_request_send():
         raise AssertionError
     if req.send(url="http://example.com", method="post").request.method != "POST":
         raise AssertionError
+
+
+def test_request_send_returns_none_on_error():
+    # A connection error (nothing listening on this local port) must be
+    # handled and return None rather than raising and aborting the scan.
+    Services.register("output", Output())
+    req = SingleRequest(timeout=2)
+    if req.send(url="http://127.0.0.1:1/") is not None:
+        raise AssertionError


### PR DESCRIPTION
Fixes #51.

> Stacked on top of #55 (base branch `fix/injection-malformed-urls`). Review/merge #55 first; GitHub will retarget this PR to `master` automatically once #55 merges.

## Problem
`SingleRequest.send()` handled errors inconsistently:
- `except TimeoutError:` caught the **builtin** `TimeoutError`, but `requests` raises `requests.exceptions.Timeout` (a `RequestException`). Real timeouts fell into the `RequestException` branch and were **re-raised**, aborting the whole scan.
- Handled paths fell off the end and returned **`None`**; every caller then did `resp.text` / `resp.headers` / `resp.status_code` → `AttributeError`.

## Fix
- Catch `requests.exceptions.Timeout` and `ConnectionError` explicitly, and **return `None` uniformly** on any handled error (no re-raise). A single failing request no longer aborts the scan.
- Guard the fingerprint runner against a `None` response so it aborts that phase cleanly with a clear message. Attack plugins already wrap each request in their own handler and now simply skip a failed request.
- Added a deterministic test that `send()` returns `None` on a connection error (connection refused on a closed local port — no external network required).

## Verification
- `make test`: **19 passed**.
- `make criticalint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)