### PR TITLE
Wire up the --random-agent flag (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python sitadel.py --help
 ## Usage
 
 ```bash
-sitadel.py [-h] [-r {0,1,2}] [-ua USER_AGENT] [--redirect]
+sitadel.py [-h] [-r {0,1,2}] [-ua USER_AGENT] [--random-agent] [--redirect]
            [--no-redirect] [-t TIMEOUT] [-c COOKIE] [-p PROXY]
            [-f FINGERPRINT [MODULE ...]] [-a ATTACK [MODULE ...]]
            [--config CONFIG] [-v] [--version]
@@ -110,6 +110,7 @@ sitadel.py [-h] [-r {0,1,2}] [-ua USER_AGENT] [--redirect]
 | -h, --help         | Display help |
 | -r, --risk {0,1,2}        | Decide the risk level you want Sitadel to run (some attacks won't be executed)          |
 | -ua, --user-agent       | User agent used for the HTTP request of the attacks          |
+| --random-agent      | Use a random User-Agent for each scan request                |
 | --redirect      | Indicates to Sitadel to follow the 302 request for page redirection                                          |
 | --no-redirect             | Indicates to Sitadel **NOT** to follow the 302 request for page redirection                |
 | -t, --timeout                    | Specify the timeout for the HTTP requests to the website                                          |

--- a/lib/request/request.py
+++ b/lib/request/request.py
@@ -1,5 +1,3 @@
-import sys
-
 from requests import Request, Session
 from requests import ConnectionError, RequestException, Timeout
 import urllib3
@@ -15,6 +13,7 @@ class SingleRequest:
         self.proxy = None if "proxy" not in kwargs else kwargs["proxy"]
         self.redirect = True if "redirect" not in kwargs else kwargs["redirect"]
         self.timeout = None if "timeout" not in kwargs else kwargs["timeout"]
+        self.random_agent = False if "random_agent" not in kwargs else kwargs["random_agent"]
         self.ruagent = ragent.RandomUserAgent()
 
     def send(self, url, method="GET", payload=None, headers=None, cookies=None):
@@ -54,8 +53,8 @@ class SingleRequest:
             headers = {}
         if cookies is not None:
             cookies = {cookies: ''}
-        if "--random-agent" in sys.argv:
-            headers['User-Agent'] = self.ruagent
+        if self.random_agent:
+            headers['User-Agent'] = ragent.RandomUserAgent()
         else:
             headers['User-Agent'] = self.agent
         # get method

--- a/sitadel.py
+++ b/sitadel.py
@@ -74,6 +74,12 @@ class Sitadel(object):
             "-p", "--proxy", help="Proxy to set for the scan HTTP requests"
         )
         parser.add_argument(
+            "--random-agent",
+            dest="random_agent",
+            action="store_true",
+            help="Use a random User-Agent for each scan request",
+        )
+        parser.add_argument(
             "-f", "--fingerprint", nargs="+", help="Fingerprint modules to activate"
         )
         parser.add_argument(
@@ -142,6 +148,7 @@ class Sitadel(object):
                 proxy=args.proxy,
                 redirect=args.redirect,
                 timeout=args.timeout,
+                random_agent=args.random_agent,
             ),
         )
 

--- a/tests/lib/request/test_request.py
+++ b/tests/lib/request/test_request.py
@@ -41,6 +41,20 @@ def test_request_send():
         raise AssertionError
 
 
+def test_random_agent():
+    # Default: the configured agent is used.
+    fixed = SingleRequest(agent="fixed-agent")
+    prepped = fixed.prepare_request("http://example.com", "GET", None, None, None)
+    if prepped.headers["User-Agent"] != "fixed-agent":
+        raise AssertionError
+
+    # With random_agent enabled, a random agent is used instead.
+    rnd = SingleRequest(agent="fixed-agent", random_agent=True)
+    prepped = rnd.prepare_request("http://example.com", "GET", None, None, None)
+    if prepped.headers["User-Agent"] == "fixed-agent":
+        raise AssertionError
+
+
 def test_request_send_returns_none_on_error():
     # A connection error (nothing listening on this local port) must be
     # handled and return None rather than raising and aborting the scan.


### PR DESCRIPTION
Fixes #52.

> Stacked on top of #56 → #55 (base branch `fix/request-error-handling`). GitHub will retarget this PR to `master` as the chain merges.

## Problem
`lib/request/request.py` enabled random User-Agents only when `"--random-agent" in sys.argv`, but `sitadel.py`'s argparse defined **no** such argument. argparse rejects unknown args, so `python sitadel.py URL --random-agent` exited with *"unrecognized arguments"* before any request ran. The feature — and `ragent.RandomUserAgent()` — was unreachable dead code.

## Fix
- Register `--random-agent` in argparse and thread the flag through to `SingleRequest`.
- Replace the `sys.argv` sniff with a real instance flag (`self.random_agent`), and select a fresh random agent **per request** rather than once at construction.
- Remove the now-unused `import sys`.
- Document the flag in the README usage section.
- Add a test asserting the configured agent is used by default and a random one when the flag is set.

## Verification
- `python sitadel.py --help` now lists `--random-agent`.
- `make test`: **20 passed**.
- `make criticalint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)