### PR TITLE
Filter plugins by risk at run time instead of import time (#53)

### DIFF
--- a/lib/config/settings.py
+++ b/lib/config/settings.py
@@ -17,12 +17,17 @@ class Risk(IntEnum):
 
 
 class Settings(object):
-    cfg = {}
+    # Safe default risk so plugin filtering works even before a config is
+    # loaded (matches the default shipped in config/config.yml).
+    cfg = {'risk': Risk.NOISY}
 
     _setters = ['risk', 'dns_resolver', 'datastore']
 
     def __getattr__(self, item):
-        return Settings.cfg[item]
+        try:
+            return Settings.cfg[item]
+        except KeyError:
+            raise AttributeError(item)
 
     def __setattr__(self, key, value):
         if key in Settings._setters:
@@ -48,5 +53,10 @@ class Settings(object):
                 config = yaml.load(yamlfile, Loader=yaml.SafeLoader)
                 # Merging the dictionaries and getting result
                 cls.cfg = {**cls.cfg, **config}
+                # Normalize the risk to the Risk enum so comparisons against
+                # plugin levels are consistent regardless of the source (an
+                # int from YAML or a Risk from the CLI).
+                if 'risk' in cls.cfg:
+                    cls.cfg['risk'] = Risk(int(cls.cfg['risk']))
             except yaml.YAMLError as e:
                 print(e)

--- a/lib/modules/__init__.py
+++ b/lib/modules/__init__.py
@@ -1,14 +1,13 @@
-from lib.config import settings
-
-
 class IPlugin(type):
     def __init__(cls, name, bases, dct):
         if not hasattr(cls, 'plugins'):
             # this is the base class.  Create an empty registry
             cls.plugins = []
         else:
-            # this is a derived class.  Add cls to the registry
-            if hasattr(cls, 'level') and getattr(cls, 'level') <= settings.risk:
-                cls.plugins.append(cls)
+            # this is a derived class.  Register it unconditionally; the
+            # risk level is applied at run time (see ``*Plugin.enabled``),
+            # not here at import time, so registration no longer depends on
+            # ``settings.risk`` being loaded before the module is imported.
+            cls.plugins.append(cls)
 
         super(IPlugin, cls).__init__(name, bases, dct)

--- a/lib/modules/attacks/__init__.py
+++ b/lib/modules/attacks/__init__.py
@@ -3,6 +3,7 @@ import os
 import pkgutil
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from lib.config import settings
 from lib.config.settings import Risk
 from lib.utils.container import Services
 from .. import IPlugin
@@ -11,6 +12,20 @@ from .. import IPlugin
 class AttackPlugin(metaclass=IPlugin):
     # Default risk level for attack modules is NOISY since it sends requests
     level = Risk.NOISY
+
+    @classmethod
+    def enabled(cls):
+        """Registered plugins whose risk level is within the configured risk.
+
+        Filtering is done here, at run time, so changing the risk level (or
+        loading the configuration after the plugins were imported) always
+        takes effect instead of depending on import ordering.
+        """
+        return [
+            plugin
+            for plugin in cls.plugins
+            if getattr(plugin, "level", Risk.NO_DANGER) <= settings.risk
+        ]
 
     @staticmethod
     def taint_url(url, payload):
@@ -60,7 +75,7 @@ class Attacks:
         try:
             attacks = [
                 (p(), p().process(self.start_url, self.crawled_urls))
-                for p in AttackPlugin.plugins
+                for p in AttackPlugin.enabled()
             ]
             for category, result in attacks:
                 if result is not None:

--- a/lib/modules/fingerprints/__init__.py
+++ b/lib/modules/fingerprints/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import pkgutil
 
+from lib.config import settings
 from lib.config.settings import Risk
 from lib.utils.container import Services
 from .. import IPlugin
@@ -10,6 +11,20 @@ from .. import IPlugin
 class FingerprintPlugin(metaclass=IPlugin):
     # Default risk level for fingerprint module is NO DANGER since it only analyze one request response
     level = Risk.NO_DANGER
+
+    @classmethod
+    def enabled(cls):
+        """Registered plugins whose risk level is within the configured risk.
+
+        Filtering is done here, at run time, so changing the risk level (or
+        loading the configuration after the plugins were imported) always
+        takes effect instead of depending on import ordering.
+        """
+        return [
+            plugin
+            for plugin in cls.plugins
+            if getattr(plugin, "level", Risk.NO_DANGER) <= settings.risk
+        ]
 
     def process(self, headers, content):
         raise NotImplementedError(str(self) + ": Process method not found")
@@ -59,7 +74,7 @@ class Fingerprints:
             # Pass the result over the fingerprint module for processing
             fingerprints = [
                 (p(), p().process(resp.headers, resp.text))
-                for p in FingerprintPlugin.plugins
+                for p in FingerprintPlugin.enabled()
             ]
 
             # Display findings for each category of modules

--- a/tests/lib/modules/attacks/test_attack.py
+++ b/tests/lib/modules/attacks/test_attack.py
@@ -28,19 +28,13 @@ def test_attack_plugin():
 def test_new_attack_plugin():
     settings.risk = Risk.NOISY
 
+    before = len(AttackPlugin.plugins)
+
     class DangerousAttackPlugin(AttackPlugin):
         level = Risk.DANGEROUS
 
         def process(self, start_url, crawled_urls):
             pass
-
-    dangerous = DangerousAttackPlugin()
-    if dangerous is None:
-        raise AssertionError
-    if dangerous.level != Risk.DANGEROUS:
-        raise AssertionError
-    if dangerous.plugins != []:
-        raise AssertionError
 
     class GoodAttackPlugin(AttackPlugin):
         level = Risk.NO_DANGER
@@ -48,14 +42,20 @@ def test_new_attack_plugin():
         def process(self, start_url, crawled_urls):
             pass
 
-    good = GoodAttackPlugin()
-    if good is None:
+    # Both plugins are registered unconditionally at definition time.
+    if len(AttackPlugin.plugins) != before + 2:
         raise AssertionError
-    if good.level != Risk.NO_DANGER:
+    if DangerousAttackPlugin not in AttackPlugin.plugins:
         raise AssertionError
-    if good.plugins == []:
+    if GoodAttackPlugin not in AttackPlugin.plugins:
         raise AssertionError
-    if id(good.plugins[0]) != id(GoodAttackPlugin):
+
+    # Risk filtering is applied at run time via enabled(): at NOISY risk the
+    # DANGEROUS plugin is excluded while the NO_DANGER one is kept.
+    enabled = AttackPlugin.enabled()
+    if DangerousAttackPlugin in enabled:
+        raise AssertionError
+    if GoodAttackPlugin not in enabled:
         raise AssertionError
 
 

--- a/tests/lib/modules/fingerprints/test_fingerprint.py
+++ b/tests/lib/modules/fingerprints/test_fingerprint.py
@@ -27,19 +27,13 @@ def test_fingerprint_plugin():
 def test_new_fingerprint_plugin():
     settings.risk = Risk.NOISY
 
+    before = len(FingerprintPlugin.plugins)
+
     class DangerousFingerPrintPlugin(FingerprintPlugin):
         level = Risk.DANGEROUS
 
         def process(self, headers, content):
             pass
-
-    dangerous = DangerousFingerPrintPlugin()
-    if dangerous is None:
-        raise AssertionError
-    if dangerous.level != Risk.DANGEROUS:
-        raise AssertionError
-    if dangerous.plugins != []:
-        raise AssertionError
 
     class GoodFingerPrintPlugin(FingerprintPlugin):
         level = Risk.NO_DANGER
@@ -47,14 +41,20 @@ def test_new_fingerprint_plugin():
         def process(self, headers, content):
             pass
 
-    good = GoodFingerPrintPlugin()
-    if good is None:
+    # Both plugins are registered unconditionally at definition time.
+    if len(FingerprintPlugin.plugins) != before + 2:
         raise AssertionError
-    if good.level != Risk.NO_DANGER:
+    if DangerousFingerPrintPlugin not in FingerprintPlugin.plugins:
         raise AssertionError
-    if good.plugins == []:
+    if GoodFingerPrintPlugin not in FingerprintPlugin.plugins:
         raise AssertionError
-    if id(good.plugins[0]) != id(GoodFingerPrintPlugin):
+
+    # Risk filtering is applied at run time via enabled(): at NOISY risk the
+    # DANGEROUS plugin is excluded while the NO_DANGER one is kept.
+    enabled = FingerprintPlugin.enabled()
+    if DangerousFingerPrintPlugin in enabled:
+        raise AssertionError
+    if GoodFingerPrintPlugin not in enabled:
         raise AssertionError
 
 


### PR DESCRIPTION
Fixes #53.

> Stacked on top of #57 → #56 → #55 (base branch `feature/random-agent-flag`). GitHub will retarget this PR to `master` as the chain merges.

## Problem
`IPlugin.__init__` evaluated `level <= settings.risk` at **class-definition (import) time** and appended survivors to a process-global `plugins` list:
- Correct behavior depended entirely on `settings.risk` being set **before** any plugin import (fragile under different import orders / reuse / tooling).
- A missing `risk` raised a raw `KeyError` from `Settings.__getattr__`.
- The registry was **never cleared**, so a plugin registered under one risk stayed for the process lifetime — you couldn't lower the risk and re-run in the same process.
- `risk` was an `int` from YAML but a `Risk` enum from the CLI.

## Fix
- `IPlugin` now registers **every** plugin unconditionally at import (discovery is decoupled from risk).
- New `AttackPlugin.enabled()` / `FingerprintPlugin.enabled()` classmethods filter by `settings.risk` **at call time**; `Attacks.run()` / `Fingerprints.run()` iterate `enabled()` instead of the raw registry.
- `Settings`: a safe default `risk` (matching `config/config.yml`), normalization to the `Risk` enum on load, and `AttributeError` (not `KeyError`) for missing keys so `hasattr` works.
- Updated the registration tests to assert the new run-time-filter contract (all plugins register; `enabled()` applies the risk filter).

## Verification
- `make test`: **20 passed**.
- `make criticalint`: clean; no unused imports (F401) in the touched modules.
- Smoke: `settings.risk` is a safe default before load and a `Risk` enum after load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)