### PR TITLE
Await all injection tasks in one bounded thread pool (#54)

### DIFF
--- a/lib/modules/attacks/injection/html.py
+++ b/lib/modules/attacks/injection/html.py
@@ -34,9 +34,8 @@ class Html(AttackPlugin):
     def process(self, start_url, crawled_urls):
         self.output.info("Checking html injection...")
         payload = '<h1><a href="https://www.github.com/shenril/Sitadel">Click Sitadel!</a></h1>'
-        # We launch ThreadPoolExecutor with max_workers to None to get default optimization
-        # https://docs.python.org/3/library/concurrent.futures.html
-        with ThreadPoolExecutor(max_workers=None) as executor:
+        # Bounded pool to avoid overwhelming the target and the local machine
+        with ThreadPoolExecutor(max_workers=20) as executor:
             futures = [
                 executor.submit(self.attack, payload, url) for url in crawled_urls
             ]

--- a/lib/modules/attacks/injection/ldap.py
+++ b/lib/modules/attacks/injection/ldap.py
@@ -61,18 +61,20 @@ class LDAP(AttackPlugin):
 
     def process(self, start_url, crawled_urls):
         self.output.info("Checking ldap injection...")
-        db = self.datastore.open("ldap.txt", "r")
-        dbfiles = [x.strip() for x in db]
-
-        for payload in dbfiles:
-            with ThreadPoolExecutor(max_workers=None) as executor:
-                futures = [
-                    executor.submit(self.attack, payload, url) for url in crawled_urls
-                ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+        with self.datastore.open("ldap.txt", "r") as db:
+            payloads = [x.strip() for x in db]
+        # Submit the whole payload x url matrix to a single bounded pool so
+        # every task is awaited and interrupts are handled once.
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [
+                executor.submit(self.attack, payload, url)
+                for payload in payloads
+                for url in crawled_urls
+            ]
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise
 

--- a/lib/modules/attacks/injection/php.py
+++ b/lib/modules/attacks/injection/php.py
@@ -36,13 +36,13 @@ class Php(AttackPlugin):
     def process(self, start_url, crawled_urls):
         self.output.info("Checking php code injection...")
         payload = "1;phpinfo()"
-        with ThreadPoolExecutor(max_workers=None) as executor:
+        with ThreadPoolExecutor(max_workers=20) as executor:
             futures = [
                 executor.submit(self.attack, payload, url) for url in crawled_urls
             ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise

--- a/lib/modules/attacks/injection/rfi.py
+++ b/lib/modules/attacks/injection/rfi.py
@@ -35,16 +35,19 @@ class Rfi(AttackPlugin):
 
     def process(self, start_url, crawled_urls):
         self.output.info("Checking remote file inclusion...")
-        db = self.datastore.open("rfi.txt", "r")
-        dbfiles = [x.rstrip("\n") for x in db]
-        for payload in dbfiles:
-            with ThreadPoolExecutor(max_workers=None) as executor:
-                futures = [
-                    executor.submit(self.attack, payload, url) for url in crawled_urls
-                ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+        with self.datastore.open("rfi.txt", "r") as db:
+            payloads = [x.rstrip("\n") for x in db]
+        # Submit the whole payload x url matrix to a single bounded pool so
+        # every task is awaited and interrupts are handled once.
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [
+                executor.submit(self.attack, payload, url)
+                for payload in payloads
+                for url in crawled_urls
+            ]
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise

--- a/lib/modules/attacks/injection/sql.py
+++ b/lib/modules/attacks/injection/sql.py
@@ -74,16 +74,19 @@ class Sql(AttackPlugin):
 
     def process(self, start_url, crawled_urls):
         self.output.info("Checking sql injection...")
-        db = self.datastore.open("sql.txt", "r")
-        dbfiles = [x.rstrip("\n") for x in db]
-        for payload in dbfiles:
-            with ThreadPoolExecutor(max_workers=None) as executor:
-                futures = [
-                    executor.submit(self.attack, payload, url) for url in crawled_urls
-                ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+        with self.datastore.open("sql.txt", "r") as db:
+            payloads = [x.rstrip("\n") for x in db]
+        # Submit the whole payload x url matrix to a single bounded pool so
+        # every task is awaited and interrupts are handled once.
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [
+                executor.submit(self.attack, payload, url)
+                for payload in payloads
+                for url in crawled_urls
+            ]
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise

--- a/lib/modules/attacks/injection/xpath.py
+++ b/lib/modules/attacks/injection/xpath.py
@@ -32,17 +32,20 @@ class Xpath(AttackPlugin):
 
     def process(self, start_url, crawled_urls):
         self.output.info("Checking xpath injection...")
-        db = self.datastore.open("xpath.txt", "r")
-        dbfiles = [x.rstrip("\n") for x in db]
-        for payload in dbfiles:
-            with ThreadPoolExecutor(max_workers=None) as executor:
-                futures = [
-                    executor.submit(self.attack, payload, url) for url in crawled_urls
-                ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+        with self.datastore.open("xpath.txt", "r") as db:
+            payloads = [x.rstrip("\n") for x in db]
+        # Submit the whole payload x url matrix to a single bounded pool so
+        # every task is awaited and interrupts are handled once.
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [
+                executor.submit(self.attack, payload, url)
+                for payload in payloads
+                for url in crawled_urls
+            ]
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise
 

--- a/lib/modules/attacks/injection/xss.py
+++ b/lib/modules/attacks/injection/xss.py
@@ -33,18 +33,21 @@ class Xss(AttackPlugin):
             return
 
     def process(self, start_url, crawled_urls):
-        db = self.datastore.open("xss.txt", "r")
-        dbfiles = [x.rstrip("\n") for x in db]
         self.output.info("Checking cross site scripting...")
-        for payload in dbfiles:
-            with ThreadPoolExecutor(max_workers=None) as executor:
-                futures = [
-                    executor.submit(self.attack, payload, url) for url in crawled_urls
-                ]
-        try:
-            for future in as_completed(futures):
-                future.result()
-        except KeyboardInterrupt:
-            executor.shutdown(False)
-            raise
+        with self.datastore.open("xss.txt", "r") as db:
+            payloads = [x.rstrip("\n") for x in db]
+        # Submit the whole payload x url matrix to a single bounded pool so
+        # every task is awaited and interrupts are handled once.
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [
+                executor.submit(self.attack, payload, url)
+                for payload in payloads
+                for url in crawled_urls
+            ]
+            try:
+                for future in as_completed(futures):
+                    future.result()
+            except KeyboardInterrupt:
+                executor.shutdown(False)
+                raise
 


### PR DESCRIPTION
Fixes #54.

> Final PR of the stack: #58 → #57 → #56 → #55 (base branch `refactor/runtime-risk-filtering`). GitHub will retarget this PR to `master` as the chain merges.

## Problem
In the injection modules, the `with ThreadPoolExecutor(...) as executor:` block was nested **inside** the `for payload in dbfiles:` loop and reassigned `futures` each iteration, while the `as_completed(futures)` / `future.result()` loop sat **outside** and ran once. Consequences:
- Only the **last** payload's futures were ever awaited — exceptions from all earlier batches were silently discarded.
- The `except KeyboardInterrupt` guard only covered the final batch.
- A brand-new `ThreadPoolExecutor(max_workers=None)` was created for **every payload line** (hundreds of pools), causing heavy thread churn.

## Fix
- Build the payload list once, then submit the full **payload × url** matrix to a **single** `ThreadPoolExecutor(max_workers=20)`.
- Collect results and handle `KeyboardInterrupt` in one loop **inside** the pool, so every task is awaited.
- Read the wordlist with a `with` block so the file handle is closed.
- Applied to `sql`, `xss`, `ldap`, `xpath`, `rfi`; `php` and `html` aligned to the same bounded-pool structure.

## Verification
- `make test`: **20 passed**; `make criticalint`: clean.
- End-to-end smoke with a stub request layer: all 7 injection modules run, send one request per payload for a parameterized URL, and correctly **skip** URLs with no query parameters (93 requests total, none to the no-param URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)