### PR TITLE
Pin pyyaml>=6.0 to fix collections.Hashable crash on Python 3.10+ (#47)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,10 @@ setup(
     install_requires=[
         "requests",
         "urllib3",
-        "pyyaml",
+        # PyYAML < 5.3 references collections.Hashable, which was removed in
+        # Python 3.10, crashing config loading. Require a version that works
+        # on modern Python (see issue #47).
+        "pyyaml>=6.0",
         "colorama",
         "scrapy"
     ],


### PR DESCRIPTION
Fixes #47.

## Problem
On Python ≥ 3.10, startup crashed in `settings.from_yaml()`:
```
AttributeError: module 'collections' has no attribute 'Hashable'
```
The traceback ends inside **PyYAML**, not Sitadel. `collections.Hashable` was removed in Python 3.10; PyYAML < 5.3 still referenced it. Sitadel already uses `SafeLoader` correctly — the only gap was that `setup.py` declared an **unpinned** `pyyaml`, so old broken versions could be installed.

## Fix
Require `pyyaml>=6.0` in `install_requires`.

## Verification
- `python setup.py --version` parses the metadata cleanly.
- Verified PyYAML 6.x loads `config/config.yml` with `SafeLoader` on modern Python without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)