### PR TITLE
Write scan details to sitadel.log by default (#45)

### DIFF
--- a/lib/utils/logs.py
+++ b/lib/utils/logs.py
@@ -1,0 +1,40 @@
+import logging
+
+
+def setup_logging(verbosity=0, logfile="sitadel.log"):
+    """Configure and return the ``sitadelLog`` logger.
+
+    The file handler always records at INFO level so ``sitadel.log`` captures
+    the scan details (including the ERROR records emitted by the modules)
+    regardless of ``--verbosity``. ``--verbosity`` only controls how much is
+    echoed to the console. Previously the whole logger inherited the root
+    level set to ``CRITICAL`` by default, so nothing was ever written to the
+    file unless ``-v`` was passed (see issue #45).
+    """
+    logger = logging.getLogger("sitadelLog")
+    logger.setLevel(logging.DEBUG)
+    # Do not let records bubble up to the root logger (avoids duplicate output)
+    logger.propagate = False
+    # Reset handlers so repeated calls don't stack duplicates
+    logger.handlers.clear()
+
+    # File handler: always capture the run details.
+    file_handler = logging.FileHandler(logfile, mode="w", encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%d-%b-%y %H:%M:%S",
+        )
+    )
+
+    # Console handler: driven by --verbosity, but errors stay visible by default.
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(min(logging.WARNING, logging.CRITICAL - (verbosity * 10)))
+    console_handler.setFormatter(
+        logging.Formatter("%(name)s - %(levelname)s - %(message)s")
+    )
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    return logger

--- a/sitadel.py
+++ b/sitadel.py
@@ -7,7 +7,6 @@
 # @license: See the file 'LICENSE.txt'
 
 import argparse
-import logging
 import sys
 import signal
 from lib import __version__
@@ -17,6 +16,7 @@ from lib.request.request import SingleRequest
 from lib.utils import banner, manager, output, validator
 from lib.utils.container import Services
 from lib.utils.datastore import Datastore
+from lib.utils.logs import setup_logging
 from lib.utils.output import Output
 
 
@@ -107,34 +107,7 @@ class Sitadel(object):
             settings.risk = Risk(args.risk)
 
         # Setting up the logger
-        logger = logging.getLogger("sitadelLog")
-        logging.basicConfig(
-            filename="sitadel.log",
-            filemode="w",
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            datefmt="%d-%b-%y %H:%M:%S",
-            level=(logging.CRITICAL - (args.verbosity * 10)),
-        )
-
-        # Create handlers
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(logging.WARNING)
-
-        file_handler = logging.FileHandler("sitadel.log")
-        file_handler.setLevel(level=(logging.CRITICAL - (args.verbosity * 10)))
-
-        # Create formatters and add it to handlers
-        console_format = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-        console_handler.setFormatter(console_format)
-
-        file_format = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-        file_handler.setFormatter(file_format)
-
-        # Add handlers to the logger
-        logger.addHandler(console_handler)
-        logger.addHandler(file_handler)
+        logger = setup_logging(args.verbosity)
 
         # Register services
         Services.register("datastore", Datastore(settings.datastore))

--- a/tests/lib/utils/test_logs.py
+++ b/tests/lib/utils/test_logs.py
@@ -1,0 +1,43 @@
+import logging
+import os
+
+from lib.utils.logs import setup_logging
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_file_captures_errors_by_default(tmp_path):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+
+    # Default verbosity (0): the file must still capture ERROR records.
+    logger = setup_logging(verbosity=0, logfile=logfile)
+    logger.error("boom-error")
+    logger.info("some-info")
+    for handler in logger.handlers:
+        handler.flush()
+
+    content = _read(logfile)
+    if "boom-error" not in content:
+        raise AssertionError("ERROR records should be written to the log file")
+    if "some-info" not in content:
+        raise AssertionError("INFO records should be written to the log file")
+
+
+def test_logger_is_configured(tmp_path):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+    logger = setup_logging(verbosity=0, logfile=logfile)
+
+    if logger.name != "sitadelLog":
+        raise AssertionError
+    # DEBUG at the logger level so handlers decide what to emit.
+    if logger.level != logging.DEBUG:
+        raise AssertionError
+    # One file + one console handler, no duplicates on repeated setup.
+    setup_logging(verbosity=0, logfile=logfile)
+    if len(logger.handlers) != 2:
+        raise AssertionError
+    if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+        raise AssertionError


### PR DESCRIPTION
Fixes #45.

## Problem
After a scan, `sitadel.log` is 0 KB. The `"sitadelLog"` logger had no explicit level, so its effective level came from the root logger, which `logging.basicConfig(level=...)` set to `logging.CRITICAL - verbosity*10` — `CRITICAL` with no `-v`. The only records emitted (`logger.error(e)`, ERROR) were therefore filtered out before any handler. `file_handler` was also pinned to `CRITICAL`, and `basicConfig(filename=..., filemode="w")` plus a separate `FileHandler` both attached to the same file.

## Fix
Extract logging into `lib/utils/logs.py::setup_logging(verbosity, logfile)` and call it from `sitadel.py`:
- logger level `DEBUG`, `propagate=False`, handlers reset (no duplicate/root handling)
- **file handler fixed at `INFO`** so `sitadel.log` always captures the run regardless of verbosity
- console handler driven by `--verbosity`, with errors still visible by default

## Verification
- New tests: the log file captures ERROR/INFO at default verbosity, and the logger is configured with exactly one file + one console handler (no duplicates).
- `make test`: **22 passed**; `make criticalint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)