### PR TITLE
Resolve datastore path relative to the package, not the CWD (#48)

### DIFF
--- a/lib/utils/datastore.py
+++ b/lib/utils/datastore.py
@@ -1,5 +1,12 @@
 import os
 
+# Directory that contains the "lib" package. datastore.py lives at
+# lib/utils/datastore.py, so three levels up is the package root (the repo
+# root when running from source, or site-packages when installed).
+_BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
 
 class Datastore:
     """
@@ -7,7 +14,13 @@ class Datastore:
     """
 
     def __init__(self, rootpath):
-        self.rootpath = rootpath
+        # Anchor a relative datastore path to the package location so the
+        # bundled wordlists are found regardless of the current working
+        # directory (e.g. after a system-wide install). See issue #48.
+        if os.path.isabs(rootpath):
+            self.rootpath = rootpath
+        else:
+            self.rootpath = os.path.join(_BASE_DIR, rootpath)
 
     def open(self, filename, mode):
-        return open(os.path.join(self.rootpath, filename), mode,encoding="utf-8")
+        return open(os.path.join(self.rootpath, filename), mode, encoding="utf-8")

--- a/tests/lib/utils/test_datastore.py
+++ b/tests/lib/utils/test_datastore.py
@@ -1,0 +1,26 @@
+import os
+
+from lib.utils.datastore import Datastore
+
+
+def test_relative_rootpath_resolves_to_package(tmp_path, monkeypatch):
+    # Run from an unrelated directory; the bundled wordlist must still open.
+    monkeypatch.chdir(str(tmp_path))
+    ds = Datastore("lib/data")
+    with ds.open("admin.txt", "r") as fh:
+        if not fh.readline():
+            raise AssertionError("bundled data file should be readable")
+
+
+def test_absolute_rootpath_is_preserved(tmp_path):
+    abs_path = str(tmp_path)
+    ds = Datastore(abs_path)
+    if ds.rootpath != abs_path:
+        raise AssertionError
+
+    # A file placed under the absolute rootpath is opened from there.
+    with open(os.path.join(abs_path, "sample.txt"), "w", encoding="utf-8") as fh:
+        fh.write("payload\n")
+    with ds.open("sample.txt", "r") as fh:
+        if fh.read().strip() != "payload":
+            raise AssertionError


### PR DESCRIPTION
Fixes #48.

## Problem
After a system-wide install, running Sitadel from any directory other than the source checkout failed:
```
sitadelLog - ERROR - [Errno 2] No such file or directory: 'lib/data/admin.txt'
```
`config/config.yml` sets `datastore: lib/data` (relative), and `Datastore.open` did `open(os.path.join(self.rootpath, filename))`, resolving against the **current working directory** rather than the installed package. The data files ship inside the package (`site-packages/lib/data/…`) but the CWD-relative path never pointed there.

## Fix
Anchor a **relative** `rootpath` to the package location — three levels up from `lib/utils/datastore.py`, i.e. the directory that contains the `lib` package (the repo root from source, or `site-packages` when installed). Absolute paths are left unchanged, so a user-provided absolute `datastore` still works.

## Verification
- New tests: the bundled `admin.txt` opens when the CWD is an unrelated directory; absolute rootpaths are preserved and read from.
- Manual: from `/tmp`, `Datastore("lib/data").open("admin.txt")` resolves to the package's absolute `lib/data/admin.txt` and reads it.
- `make test`: **22 passed**; `make criticalint`: clean.

Note: locating a default `config.yml` for installed use (the other half of the report) is a separate concern better handled with the packaging modernization in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)