### PR TITLE
Replace Scrapy with a fast async aiohttp + selectolax crawler

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -13,6 +13,17 @@ dns_resolver: 8.8.8.8
 ## Root location for the datafile used by the plugins
 datastore: lib/data
 
+## Crawler tuning
+## URLs are de-duplicated by their parameter signature (scheme, host, path and the
+## set of parameter names), so value permutations like ?id=1 / ?id=2 collapse to a
+## single representative page instead of exploding the crawl.
+crawler:
+  max_depth: 3          # how many link hops from the start URL to follow
+  max_pages: 500        # hard cap on discovered pages
+  concurrency: 20       # simultaneous in-flight requests
+  timeout: 15           # per-request timeout in seconds
+  ignore_params: []     # parameter names dropped before signing (e.g. utm_source)
+
 ## List of fingerprint plugins activated
 fingerprint_plugins:
   - cms

--- a/lib/modules/crawler/crawler.py
+++ b/lib/modules/crawler/crawler.py
@@ -1,66 +1,140 @@
-from urllib.parse import urlparse
+from __future__ import annotations
 
-from scrapy.crawler import CrawlerProcess
-from scrapy.linkextractors import LinkExtractor
-from scrapy.spiders import CrawlSpider, Rule
-from scrapy.utils.project import get_project_settings
+import asyncio
+from urllib.parse import parse_qsl, urljoin, urlsplit
 
+import aiohttp
+from selectolax.parser import HTMLParser
+
+from lib.config import settings
 from lib.utils.container import Services
 
-urls = set()
-allowed_domains = []
+# Default crawl bounds; overridable through the optional `crawler:` config block.
+_DEFAULTS = {
+    "max_depth": 3,
+    "max_pages": 500,
+    "concurrency": 20,
+    "timeout": 15,
+    "ignore_params": [],
+}
 
 
-class SitadelSpider(CrawlSpider):
-    name = "sitadel"
+def _config() -> dict:
+    cfg = dict(_DEFAULTS)
+    cfg.update(getattr(settings, "crawler", None) or {})
+    return cfg
 
-    rules = [
-        Rule(
-            LinkExtractor(canonicalize=True, unique=True),
-            follow=True,
-            process_links="parse_items",
+
+def url_signature(url: str, ignore_params=()) -> tuple:
+    """Signature that collapses URLs differing only in query-parameter *values*.
+
+    Two URLs sharing scheme, host, path and the same set of parameter *names* map to
+    the same signature, so ``?id=1`` and ``?id=2`` are one endpoint shape. This is what
+    keeps parameter permutations from exploding the crawl frontier, while still keeping a
+    representative (parameterized) URL per shape for the attack phase to inject into.
+    """
+    parts = urlsplit(url)
+    keys = tuple(
+        sorted(
+            key
+            for key, _ in parse_qsl(parts.query, keep_blank_values=True)
+            if key not in ignore_params
         )
-    ]
+    )
+    return (parts.scheme.lower(), parts.netloc.lower(), parts.path, keys)
 
-    # Method for parsing items
-    @classmethod
-    def parse_items(cls, links):
-        for link in links:
-            if urlparse(link.url).netloc in allowed_domains:
-                urls.add(link.url)
-                yield link
+
+def _extract_links(base_url: str, html: str) -> list[str]:
+    tree = HTMLParser(html)
+    base = base_url
+    base_node = tree.css_first("base[href]")
+    if base_node is not None:
+        base = urljoin(base_url, base_node.attributes.get("href") or "")
+
+    links = []
+    for node in tree.css("a[href]"):
+        href = node.attributes.get("href")
+        if not href:
+            continue
+        absolute = urljoin(base, href)
+        if urlsplit(absolute).scheme not in ("http", "https"):
+            continue
+        links.append(absolute.split("#", 1)[0])  # drop fragment
+    return links
+
+
+async def _fetch(session: aiohttp.ClientSession, url: str, timeout: int) -> str | None:
+    try:
+        async with session.get(
+            url, timeout=aiohttp.ClientTimeout(total=timeout)
+        ) as resp:
+            ctype = resp.headers.get("Content-Type", "").lower()
+            if resp.status != 200 or "html" not in ctype:
+                return None
+            raw = await resp.read()
+            return raw.decode(resp.charset or "utf-8", errors="ignore")
+    except Exception:
+        # A single failing request must never abort the crawl.
+        return None
+
+
+async def _crawl(start_url: str, user_agent: str, cfg: dict) -> list[str]:
+    host = urlsplit(start_url).hostname
+    ignore = tuple(cfg["ignore_params"])
+    max_depth = cfg["max_depth"]
+    max_pages = cfg["max_pages"]
+    concurrency = cfg["concurrency"]
+    timeout = cfg["timeout"]
+
+    seen = {url_signature(start_url, ignore)}
+    results = {start_url}
+    queue: asyncio.Queue = asyncio.Queue()
+    queue.put_nowait((start_url, 0))
+
+    connector = aiohttp.TCPConnector(
+        limit=concurrency, limit_per_host=concurrency, ssl=False
+    )
+    headers = {"User-Agent": user_agent}
+
+    async with aiohttp.ClientSession(connector=connector, headers=headers) as session:
+
+        async def worker():
+            while True:
+                url, depth = await queue.get()
+                try:
+                    if len(results) > max_pages:
+                        continue
+                    html = await _fetch(session, url, timeout)
+                    if html is None or depth >= max_depth:
+                        continue
+                    for link in _extract_links(url, html):
+                        if urlsplit(link).hostname != host:
+                            continue
+                        sig = url_signature(link, ignore)
+                        if sig in seen:
+                            continue
+                        seen.add(sig)
+                        # Cap the number of discovered pages. No await between the
+                        # check and the add, so this stays consistent across workers.
+                        if len(results) >= max_pages:
+                            continue
+                        results.add(link)
+                        queue.put_nowait((link, depth + 1))
+                except Exception:
+                    pass
+                finally:
+                    queue.task_done()
+
+        workers = [asyncio.create_task(worker()) for _ in range(concurrency)]
+        await queue.join()
+        for task in workers:
+            task.cancel()
+        await asyncio.gather(*workers, return_exceptions=True)
+
+    return sorted(results)
+
 
 def crawl(url, user_agent):
-    try:
-        output = Services.get("output")
-
-        # Settings for the crawler
-        settings = get_project_settings()
-        settings.set("USER_AGENT", user_agent)
-        settings.set("LOG_LEVEL", "CRITICAL")
-        settings.set("RETRY_ENABLED", False)
-        settings.set("CONCURRENT_REQUESTS", 15)
-
-        # Create the process that will perform the crawl
-        output.info("Start crawling the target website")
-        process = CrawlerProcess(settings)
-        allowed_domains.append(str(urlparse(url).hostname))
-        process.crawl(
-            SitadelSpider, start_urls=[str(url)], allowed_domains=allowed_domains
-        )
-        process.start()
-
-        # Clean the results
-        clean_urls = []
-        for u in urls:
-            try:
-                new_url = urlparse(u).geturl()
-                clean_urls.append(new_url)
-            except ValueError:
-                continue
-        return clean_urls
-
-    except KeyboardInterrupt:
-        process.stop()
-        raise
-
+    output = Services.get("output")
+    output.info("Start crawling the target website")
+    return asyncio.run(_crawl(str(url), user_agent, _config()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "urllib3>=2",
     "pyyaml>=6.0",
     "colorama>=0.4",
-    "scrapy>=2.11",
+    "aiohttp>=3.9",
+    "selectolax>=0.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/lib/modules/crawler/test_crawler.py
+++ b/tests/lib/modules/crawler/test_crawler.py
@@ -1,0 +1,122 @@
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import TCPServer, ThreadingMixIn
+from urllib.parse import urlsplit
+
+import pytest
+
+from lib.config import settings
+from lib.modules.crawler.crawler import crawl, url_signature
+from lib.utils.container import Services
+from lib.utils.output import Output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the parameter-signature de-duplication
+# ---------------------------------------------------------------------------
+def test_signature_collapses_parameter_values():
+    a = url_signature("http://host/item?id=1")
+    b = url_signature("http://host/item?id=2")
+    # Same path + same parameter names => same signature (values ignored).
+    if a != b:
+        raise AssertionError
+
+
+def test_signature_distinguishes_parameter_names_and_paths():
+    base = url_signature("http://host/item?id=1")
+    if url_signature("http://host/item?id=1&sort=asc") == base:
+        raise AssertionError  # extra parameter name -> different shape
+    if url_signature("http://host/other?id=1") == base:
+        raise AssertionError  # different path -> different shape
+
+
+def test_signature_ignore_params():
+    a = url_signature("http://host/p?id=1&utm_source=x", ignore_params=("utm_source",))
+    b = url_signature("http://host/p?id=1", ignore_params=("utm_source",))
+    if a != b:
+        raise AssertionError
+
+
+# ---------------------------------------------------------------------------
+# Integration test against a local synthetic site
+# ---------------------------------------------------------------------------
+class _Server(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+    def server_bind(self):
+        # Skip HTTPServer's slow socket.getfqdn() reverse-DNS lookup.
+        TCPServer.server_bind(self)
+        host, port = self.socket.getsockname()[:2]
+        self.server_name = host
+        self.server_port = port
+
+
+class _Handler(BaseHTTPRequestHandler):
+    hits: list[str] = []
+
+    def log_message(self, *args):  # silence the server
+        pass
+
+    def do_GET(self):
+        _Handler.hits.append(self.path)
+        path = urlsplit(self.path).path
+        if path == "/":
+            # 50 value-permutations of one shape, plus two other distinct shapes.
+            links = "".join(f'<a href="/item?id={i}">i{i}</a>' for i in range(50))
+            links += '<a href="/item?id=1&sort=asc">sorted</a>'
+            links += '<a href="/page2">next</a>'
+            links += '<a href="http://example.org/out">offsite</a>'
+            body = f"<html><body>{links}</body></html>"
+        else:
+            body = "<html><body>leaf</body></html>"
+        raw = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+@pytest.fixture
+def local_site():
+    _Handler.hits = []
+    server = _Server(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_crawl_collapses_parameter_permutations(local_site):
+    Services.register("output", Output())
+    settings.cfg["crawler"] = {"max_depth": 3, "max_pages": 500, "concurrency": 8}
+
+    results = crawl(local_site, "test-agent")
+
+    # 50 ?id=<n> links share one signature, so only ONE of them is fetched — not 50.
+    item_fetches = [h for h in _Handler.hits if h.startswith("/item?id=") and "sort" not in h]
+    if len(item_fetches) != 1:
+        raise AssertionError(f"expected 1 /item fetch, got {len(item_fetches)}: {item_fetches}")
+
+    # A representative parameterized URL is returned for the attack phase.
+    if not any("/item?id=" in u for u in results):
+        raise AssertionError("expected a representative parameterized URL in results")
+
+    # Distinct shapes are still discovered; off-site links are excluded.
+    if not any("/item?id=1&sort=asc" in u for u in results):
+        raise AssertionError("distinct parameter shape should be crawled")
+    if any("example.org" in u for u in results):
+        raise AssertionError("off-site URLs must be excluded")
+
+
+def test_crawl_respects_max_pages(local_site):
+    Services.register("output", Output())
+    settings.cfg["crawler"] = {"max_depth": 3, "max_pages": 2, "concurrency": 4}
+
+    results = crawl(local_site, "test-agent")
+    if len(results) > 2:
+        raise AssertionError(f"max_pages not respected: {len(results)} results")


### PR DESCRIPTION
Addresses the crawling performance problem, especially on pages with parameters.

## Problem
The crawler delegated to **Scrapy** (`CrawlerProcess` + `CrawlSpider`, `follow=True`, `CONCURRENT_REQUESTS=15`) with **no URL normalization and no crawl limits**. On parameterized sites, every query-parameter *value* permutation (`?id=1`, `?id=2`, pagination, sorting, session/CSRF tokens) looks like a distinct URL, so the frontier explodes into thousands of near-duplicate pages. Scrapy's per-run Twisted reactor adds fixed startup overhead on top, and it's the heaviest dependency in the project.

## Approach
A small custom **async** crawler — **aiohttp** (bounded-concurrency client; httpx has O(n²) queuing overhead at scale) + **selectolax** (C/lexbor parser, ~30× faster than BeautifulSoup) — replacing Scrapy entirely.

**Core optimization — parameter-signature dedup:** URLs are de-duplicated by
`(scheme, host, path, sorted(param_names))`, so all value permutations of an endpoint collapse to **one representative fetch**. The first full (parameterized) URL per shape is kept, so the injection modules still get a real target to taint — but one per endpoint shape instead of thousands of redundant ones (faster *and* better results).

Also: bounded crawl (`max_depth`, `max_pages`, `concurrency`, `timeout` — all configurable via a new optional `crawler:` block in `config.yml`), same-domain restriction, `<base href>` handling, fragment stripping, per-request error isolation, and removal of the module-level mutable globals (the crawler is now reentrant). Public `crawl(url, user_agent) -> list[str]` is unchanged, so `manager.py` and the attack phase are untouched.

**Dependencies:** drop `scrapy`, add `aiohttp>=3.9`, `selectolax>=0.3`.

## Benchmark
Local synthetic site advertising **2000** `?id=<n>` permutations + 2 other shapes:

| | requests issued | wall time |
|---|---|---|
| naive / old (one fetch per distinct URL) | ~2002 | — |
| **this crawler** | **4** | **~18 ms** |

It returns 4 representative URLs — one per endpoint shape.

## Verification
- `make test` (`-m "not dangerous"`): **30 passed** (added 5 crawler tests — signature unit tests + a deterministic local-`http.server` integration test proving the 50→1 collapse, off-site exclusion, and `max_pages`); `make criticalint`: clean.
- `python -m build` produces a wheel whose `Requires-Dist` lists aiohttp/selectolax and **no scrapy**; the crawler imports without scrapy installed.

## Notes
- Feature parity: the old code did not obey robots.txt or retry, so no regression there; selectolax's lexbor engine tolerates malformed HTML.
- Proxy is still not passed to the crawler (only `url`, `user_agent`, as before) — wiring proxy/timeout through is a small future extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)