### PR TITLE
Structured findings store + report generation (JSON/HTML/SARIF) (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .idea/
 .cache/
 .python-version
+# runtime log
+sitadel.log

--- a/lib/report/__init__.py
+++ b/lib/report/__init__.py
@@ -1,0 +1,19 @@
+from .report import (
+    Finding,
+    Findings,
+    Severity,
+    to_html,
+    to_json,
+    to_sarif,
+    write_report,
+)
+
+__all__ = [
+    "Finding",
+    "Findings",
+    "Severity",
+    "to_html",
+    "to_json",
+    "to_sarif",
+    "write_report",
+]

--- a/lib/report/report.py
+++ b/lib/report/report.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import html as _html
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+
+class Severity(str, Enum):
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class Finding:
+    """A single scan finding reported by a plugin."""
+
+    title: str
+    severity: Severity = Severity.INFO
+    url: str | None = None
+    parameter: str | None = None
+    evidence: str | None = None
+    confidence: str | None = None
+    plugin: str | None = None
+    cwe: str | None = None
+
+
+class Findings:
+    """Collector for findings, registered in the Services container."""
+
+    def __init__(self):
+        self._items: list[Finding] = []
+
+    def add(self, finding: Finding) -> None:
+        self._items.append(finding)
+
+    def all(self) -> list[Finding]:
+        return list(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+
+def _to_dict(finding: Finding) -> dict:
+    data = asdict(finding)
+    data["severity"] = (
+        finding.severity.value
+        if isinstance(finding.severity, Severity)
+        else finding.severity
+    )
+    return data
+
+
+def to_json(findings: list[Finding]) -> str:
+    return json.dumps([_to_dict(f) for f in findings], indent=2)
+
+
+# SARIF level per severity (SARIF only knows note/warning/error).
+_SARIF_LEVEL = {
+    Severity.INFO: "note",
+    Severity.LOW: "note",
+    Severity.MEDIUM: "warning",
+    Severity.HIGH: "error",
+    Severity.CRITICAL: "error",
+}
+
+
+def to_sarif(findings: list[Finding]) -> str:
+    results = []
+    for f in findings:
+        severity = f.severity if isinstance(f.severity, Severity) else Severity.INFO
+        result = {
+            "ruleId": f.plugin or f.title,
+            "level": _SARIF_LEVEL.get(severity, "note"),
+            "message": {"text": f.title},
+        }
+        if f.url:
+            result["locations"] = [
+                {"physicalLocation": {"artifactLocation": {"uri": f.url}}}
+            ]
+        results.append(result)
+    doc = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {"tool": {"driver": {"name": "Sitadel"}}, "results": results}
+        ],
+    }
+    return json.dumps(doc, indent=2)
+
+
+def to_html(findings: list[Finding]) -> str:
+    rows = []
+    for f in findings:
+        severity = f.severity.value if isinstance(f.severity, Severity) else f.severity
+        cells = [
+            _html.escape(severity or ""),
+            _html.escape(f.title or ""),
+            _html.escape(f.url or ""),
+            _html.escape(f.evidence or ""),
+        ]
+        rows.append("<tr>" + "".join(f"<td>{c}</td>" for c in cells) + "</tr>")
+    body = "\n".join(rows) or '<tr><td colspan="4">No findings</td></tr>'
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<title>Sitadel report</title>"
+        "<style>body{font-family:sans-serif}table{border-collapse:collapse;width:100%}"
+        "th,td{border:1px solid #ccc;padding:6px;text-align:left}"
+        "th{background:#222;color:#fff}</style></head><body>"
+        f"<h1>Sitadel report</h1><p>{len(findings)} finding(s)</p>"
+        "<table><thead><tr><th>Severity</th><th>Title</th><th>URL</th>"
+        f"<th>Evidence</th></tr></thead><tbody>{body}</tbody></table>"
+        "</body></html>"
+    )
+
+
+_SERIALIZERS = {"json": to_json, "sarif": to_sarif, "html": to_html}
+
+
+def write_report(findings: list[Finding], fmt: str, path: str) -> None:
+    """Serialize ``findings`` in ``fmt`` and write to ``path``."""
+    serializer = _SERIALIZERS[fmt]
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(serializer(findings))

--- a/lib/utils/output.py
+++ b/lib/utils/output.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from colorama import Fore, Style
 
+from lib.report import Finding, Severity
+from lib.utils.container import Services
+
 
 class Output:
     r = Fore.RED
@@ -14,8 +17,19 @@ class Output:
     def __init__(self, level: int = 0):
         self.level = level
 
-    def finding(self, value: str) -> None:
+    def finding(self, value: str, severity: Severity = Severity.INFO,
+                url: str | None = None, plugin: str | None = None) -> None:
         print(f"{self.g}[+]{self.e} {self.w}{value}{self.e}", flush=True)
+        # Also record the finding for report generation, when a collector is
+        # registered. Console output above is emitted unconditionally.
+        try:
+            collector = Services.get("findings")
+        except NameError:
+            collector = None
+        if collector is not None:
+            collector.add(
+                Finding(title=value, severity=severity, url=url, plugin=plugin)
+            )
 
     def error(self, value: str) -> None:
         print(f"{self.r}[-]{self.e} {self.w}{value}{self.e}", flush=True)

--- a/sitadel.py
+++ b/sitadel.py
@@ -15,6 +15,7 @@ from lib.config.settings import Risk
 from lib.request.request import SingleRequest
 from lib.utils import banner, manager, output, validator
 from lib.utils.container import Services
+from lib.report import Findings, write_report
 from lib.utils.datastore import Datastore
 from lib.utils.logs import setup_logging
 from lib.utils.output import Output
@@ -89,6 +90,16 @@ class Sitadel(object):
             "--config", help="Path to the config file", default="config/config.yml"
         )
         parser.add_argument(
+            "-o", "--output", help="Path to write the findings report to"
+        )
+        parser.add_argument(
+            "--format",
+            dest="report_format",
+            choices=["stdout", "json", "html", "sarif"],
+            default="stdout",
+            help="Report format for the findings (default: stdout only)",
+        )
+        parser.add_argument(
             "-v",
             "--verbosity",
             action="count",
@@ -113,6 +124,7 @@ class Sitadel(object):
         Services.register("datastore", Datastore(settings.datastore))
         Services.register("logger", logger)
         Services.register("output", Output())
+        Services.register("findings", Findings())
         Services.register(
             "request_factory",
             SingleRequest(
@@ -146,6 +158,15 @@ class Sitadel(object):
         except KeyboardInterrupt:
             raise
         finally:
+            # Write the findings report (console findings are printed live by
+            # Output.finding regardless of the chosen format).
+            if args.report_format != "stdout":
+                findings = Services.get("findings").all()
+                path = args.output or f"sitadel-report.{args.report_format}"
+                write_report(findings, args.report_format, path)
+                Services.get("output").info(
+                    f"Wrote {len(findings)} finding(s) to {path}"
+                )
             self.bn.postscript()
 
 

--- a/tests/lib/report/test_report.py
+++ b/tests/lib/report/test_report.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+from lib.report import (
+    Finding,
+    Findings,
+    Severity,
+    to_html,
+    to_json,
+    to_sarif,
+    write_report,
+)
+
+
+def _sample():
+    return [
+        Finding(title="SQL Injection", severity=Severity.HIGH,
+                url="http://host/p?id=1", evidence="MySQL error", plugin="Sql"),
+        Finding(title="Missing CSP header", severity=Severity.LOW,
+                url="http://host/"),
+    ]
+
+
+def test_collector_add_and_all():
+    coll = Findings()
+    if len(coll) != 0:
+        raise AssertionError
+    coll.add(_sample()[0])
+    if len(coll) != 1 or coll.all()[0].title != "SQL Injection":
+        raise AssertionError
+
+
+def test_to_json_is_valid_and_serializes_severity():
+    data = json.loads(to_json(_sample()))
+    if len(data) != 2:
+        raise AssertionError
+    if data[0]["severity"] != "high":  # enum serialized to its string value
+        raise AssertionError
+    if data[0]["title"] != "SQL Injection":
+        raise AssertionError
+
+
+def test_to_sarif_is_valid():
+    doc = json.loads(to_sarif(_sample()))
+    if doc["version"] != "2.1.0":
+        raise AssertionError
+    if doc["runs"][0]["tool"]["driver"]["name"] != "Sitadel":
+        raise AssertionError
+    if len(doc["runs"][0]["results"]) != 2:
+        raise AssertionError
+
+
+def test_to_html_contains_findings():
+    out = to_html(_sample())
+    if "SQL Injection" not in out or "Missing CSP header" not in out:
+        raise AssertionError
+
+
+def test_write_report(tmp_path):
+    path = os.path.join(str(tmp_path), "report.json")
+    write_report(_sample(), "json", path)
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if len(data) != 2:
+        raise AssertionError

--- a/tests/lib/utils/test_output.py
+++ b/tests/lib/utils/test_output.py
@@ -1,0 +1,32 @@
+from lib.report import Findings, Severity
+from lib.utils.container import Services
+from lib.utils.output import Output
+
+
+def test_finding_prints_without_collector(capsys):
+    # No "findings" collector registered: still prints, no crash.
+    Services.services.pop("findings", None)
+    Output().finding("standalone finding")
+    captured = capsys.readouterr()
+    if "standalone finding" not in captured.out:
+        raise AssertionError
+
+
+def test_finding_prints_and_records_when_collector_registered(capsys):
+    collector = Findings()
+    Services.register("findings", collector)
+    try:
+        Output().finding("recorded finding", severity=Severity.HIGH,
+                         url="http://host/x", plugin="Demo")
+        captured = capsys.readouterr()
+        # Console output preserved (stdout still shows findings).
+        if "recorded finding" not in captured.out:
+            raise AssertionError
+        # And it was captured for the report.
+        if len(collector) != 1:
+            raise AssertionError
+        item = collector.all()[0]
+        if item.title != "recorded finding" or item.severity != Severity.HIGH:
+            raise AssertionError
+    finally:
+        Services.services.pop("findings", None)


### PR DESCRIPTION
Fixes #69.

## Problem
Findings were only printed to stdout via `Output.finding()` — no aggregation, no severity, and **no report file**. The "generate reports about findings" part of the workflow was missing.

## Change (keeps the plugin system & CLI flow)
- **`lib/report/`**: a `Finding` dataclass + `Severity` enum, a `Findings` collector registered in the existing `Services` container, and **JSON / SARIF / HTML** serializers.
- **`Output.finding()`** now *also* records a structured `Finding` when a collector is registered — the console line is still printed unconditionally, so **stdout findings are unchanged** and existing plugins need no edits (incremental severity/CWE enrichment can follow).
- **`sitadel.py`**: new `-o/--output` and `--format {stdout,json,html,sarif}` options (default `stdout` = today's behavior); the report is written in the `finally` block after the scan phases.

## Verification
- `make test`: **32 passed** (added serializer/collector tests + an `Output`→collector bridge test asserting stdout is preserved); `make criticalint`: clean.
- **End-to-end CLI run** against a local server: findings still print to stdout (48 `[+]` lines) **and** `--format json -o report.json` additionally wrote a valid JSON report of the same 48 findings.

Independent of #73 (they touch disjoint regions of `sitadel.py`); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)