### PR TITLE
HTTP client hardening & performance: pooled session + opt-in TLS verify (#73)

### DIFF
--- a/lib/modules/attacks/bruteforce/admin.py
+++ b/lib/modules/attacks/bruteforce/admin.py
@@ -32,7 +32,7 @@ class Admin(AttackPlugin):
             )
             # We launch ThreadPoolExecutor with max_workers to None to get default optimization
             # https://docs.python.org/3/library/concurrent.futures.html
-            with ThreadPoolExecutor(max_workers=None) as executor:
+            with ThreadPoolExecutor(max_workers=20) as executor:
                 futures = [executor.submit(self.check_url, url) for url in urls]
                 try:
                     for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/backdoor.py
+++ b/lib/modules/attacks/bruteforce/backdoor.py
@@ -29,7 +29,7 @@ class Backdoor(AttackPlugin):
             urls = map(lambda backdoor: urljoin(str(start_url), str(backdoor)), dbfiles)
             # We launch ThreadPoolExecutor with max_workers to None to get default optimization
             # https://docs.python.org/3/library/concurrent.futures.html
-            with ThreadPoolExecutor(max_workers=None) as executor:
+            with ThreadPoolExecutor(max_workers=20) as executor:
                 futures = [executor.submit(self.check_url, url) for url in urls]
                 try:
                     for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/bdir.py
+++ b/lib/modules/attacks/bruteforce/bdir.py
@@ -36,7 +36,7 @@ class Bdir(AttackPlugin):
                 urls.append(urljoin(str(start_url), str(bdir)))
         # We launch ThreadPoolExecutor with max_workers to None to get default optimization
         # https://docs.python.org/3/library/concurrent.futures.html
-        with ThreadPoolExecutor(max_workers=None) as executor:
+        with ThreadPoolExecutor(max_workers=20) as executor:
             futures = [executor.submit(self.check_url, url) for url in urls]
             try:
                 for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/bfile.py
+++ b/lib/modules/attacks/bruteforce/bfile.py
@@ -35,7 +35,7 @@ class Bfile(AttackPlugin):
                 urls.append(urljoin(str(start_url), str(bdir)))
         # We launch ThreadPoolExecutor with max_workers to None to get default optimization
         # https://docs.python.org/3/library/concurrent.futures.html
-        with ThreadPoolExecutor(max_workers=None) as executor:
+        with ThreadPoolExecutor(max_workers=20) as executor:
             futures = [executor.submit(self.check_url, url) for url in urls]
             try:
                 for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/dir.py
+++ b/lib/modules/attacks/bruteforce/dir.py
@@ -37,7 +37,7 @@ class Dir(AttackPlugin):
             urls = map(lambda d: urljoin(str(start_url), str(d)), dbfiles)
             # We launch ThreadPoolExecutor with max_workers to None to get default optimization
             # https://docs.python.org/3/library/concurrent.futures.html
-            with ThreadPoolExecutor(max_workers=None) as executor:
+            with ThreadPoolExecutor(max_workers=20) as executor:
                 futures = [executor.submit(self.check_url, url) for url in urls]
                 try:
                     for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/file.py
+++ b/lib/modules/attacks/bruteforce/file.py
@@ -30,7 +30,7 @@ class File(AttackPlugin):
             urls = map(lambda filex: urljoin(str(start_url), str(filex)), dbfiles)
             # We launch ThreadPoolExecutor with max_workers to None to get default optimization
             # https://docs.python.org/3/library/concurrent.futures.html
-            with ThreadPoolExecutor(max_workers=None) as executor:
+            with ThreadPoolExecutor(max_workers=20) as executor:
                 futures = [executor.submit(self.check_url, url) for url in urls]
                 try:
                     for future in as_completed(futures):

--- a/lib/modules/attacks/bruteforce/log.py
+++ b/lib/modules/attacks/bruteforce/log.py
@@ -30,7 +30,7 @@ class Log(AttackPlugin):
             urls = map(lambda log: urljoin(str(start_url), str(log)), dbfiles)
             # We launch ThreadPoolExecutor with max_workers to None to get default optimization
             # https://docs.python.org/3/library/concurrent.futures.html
-            with ThreadPoolExecutor(max_workers=None) as executor:
+            with ThreadPoolExecutor(max_workers=20) as executor:
                 futures = [executor.submit(self.check_url, url) for url in urls]
                 try:
                     for future in as_completed(futures):

--- a/lib/request/request.py
+++ b/lib/request/request.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import urllib3
 from requests import ConnectionError, Request, RequestException, Session, Timeout
+from requests.adapters import HTTPAdapter
 
 from lib.utils.container import Services
 from . import ragent as ragent
+
+# Sized to the attack phase's bounded thread pools so connections are reused.
+_POOL_SIZE = 20
 
 
 class SingleRequest:
@@ -16,6 +20,7 @@ class SingleRequest:
         redirect: bool = True,
         timeout: int | None = None,
         random_agent: bool = False,
+        verify: bool = False,
     ):
         self.url = url
         self.agent = agent
@@ -23,20 +28,28 @@ class SingleRequest:
         self.redirect = redirect
         self.timeout = timeout
         self.random_agent = random_agent
+        self.verify = verify
         self.ruagent = ragent.RandomUserAgent()
+
+        # Reuse one pooled session (keep-alive) across every request instead of
+        # opening a fresh TCP/TLS connection per call.
+        self.session = Session()
+        adapter = HTTPAdapter(pool_connections=_POOL_SIZE, pool_maxsize=_POOL_SIZE)
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
+        if not self.verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def send(self, url, method="GET", payload=None, headers=None, cookies=None):
         output = Services.get("output")
-        session = Session()
         prepped = self.prepare_request(url, method, payload, headers, cookies)
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         try:
-            return session.send(
+            return self.session.send(
                 prepped,
                 timeout=self.timeout,
                 proxies={"http": self.proxy, "https": self.proxy, "ftp": self.proxy},
                 allow_redirects=self.redirect,
-                verify=False,
+                verify=self.verify,
             )
         except Timeout:
             # requests raises requests.exceptions.Timeout (a RequestException),

--- a/sitadel.py
+++ b/sitadel.py
@@ -80,6 +80,12 @@ class Sitadel(object):
             help="Use a random User-Agent for each scan request",
         )
         parser.add_argument(
+            "--verify",
+            dest="verify",
+            action="store_true",
+            help="Verify the server's TLS certificate (off by default)",
+        )
+        parser.add_argument(
             "-f", "--fingerprint", nargs="+", help="Fingerprint modules to activate"
         )
         parser.add_argument(
@@ -122,6 +128,7 @@ class Sitadel(object):
                 redirect=args.redirect,
                 timeout=args.timeout,
                 random_agent=args.random_agent,
+                verify=args.verify,
             ),
         )
 

--- a/tests/lib/request/test_request.py
+++ b/tests/lib/request/test_request.py
@@ -62,3 +62,27 @@ def test_request_send_returns_none_on_error():
     req = SingleRequest(timeout=2)
     if req.send(url="http://127.0.0.1:1/") is not None:
         raise AssertionError
+
+
+def test_pooled_session_is_reused():
+    Services.register("output", Output())
+    req = SingleRequest()
+    # A single pooled Session is created once and reused across requests.
+    if not isinstance(req.session, requests.Session):
+        raise AssertionError
+    first = req.session
+    req.send(url="http://example.com")
+    req.send(url="http://example.com")
+    if req.session is not first:
+        raise AssertionError
+    # The HTTP adapter is a pooled one (not the requests default of maxsize 10).
+    adapter = req.session.get_adapter("http://example.com")
+    if adapter._pool_maxsize < 20:
+        raise AssertionError
+
+
+def test_tls_verification_is_opt_in():
+    if SingleRequest().verify is not False:
+        raise AssertionError
+    if SingleRequest(verify=True).verify is not True:
+        raise AssertionError


### PR DESCRIPTION
Addresses #73.

## Problem
`SingleRequest.send()` created a **brand-new `requests.Session` on every call**, so TCP/TLS was renegotiated per request — expensive for the thread-pooled attack phase — and `verify=False` was hardcoded with no way to enable verification. Several `bruteforce/*` modules also used unbounded `max_workers=None` pools.

## Change
- **Pooled session:** one `requests.Session` created in `__init__`, with an `HTTPAdapter` sized to the attack pools (`pool_connections=pool_maxsize=20`), reused across all requests (keep-alive / connection reuse). Same `send()` signature and None-on-error contract.
- **Opt-in TLS verification:** new `--verify` CLI flag (default off = current behavior), threaded into `SingleRequest`; warnings are only silenced when not verifying.
- **Bounded pools:** the 7 `bruteforce/*` modules now use `max_workers=20` (consistent with the injection modules).

## Verification
- `make test`: **27 passed** (added tests for pooled-session reuse, adapter pool size, and the verify flag); `make criticalint`: clean.
- **End-to-end CLI run** against a local server: `--verify` appears in `--help`, and findings still print to stdout (49 `[+]` lines) with the pooled session.

Independent of #74 (#69) — the two PRs touch disjoint regions of `sitadel.py` and can merge in either order.

## Deferred
Rate-limiting and scope controls listed in #73 are left as a focused follow-up (they need a throttling primitive + config); this PR delivers the pooling/verify/bounded-pool core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)