### PR TITLE
Authentication & session handling (#77)

### DIFF
--- a/lib/request/auth.py
+++ b/lib/request/auth.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import base64
+import threading
+
+from selectolax.parser import HTMLParser
+
+
+class Authenticator:
+    """Holds authentication state for a scan and applies it to requests.
+
+    Supports HTTP Basic, static Bearer tokens, arbitrary extra headers, and
+    form-based login (with optional CSRF-token extraction). Session cookies
+    obtained at login live in the shared ``requests.Session`` cookie jar and
+    are merged into every subsequent request by :class:`SingleRequest`.
+    """
+
+    def __init__(self, headers=None, login_url=None, login_data=None,
+                 csrf_field=None, logged_in_check=None):
+        self.headers = dict(headers or {})
+        self.login_url = login_url
+        self.login_data = dict(login_data or {})
+        self.csrf_field = csrf_field
+        self.logged_in_check = logged_in_check
+        self._lock = threading.Lock()
+
+    @classmethod
+    def from_options(cls, *, basic=None, bearer=None, headers=None,
+                     login_url=None, login_data=None, csrf_field=None,
+                     logged_in_check=None):
+        """Build an Authenticator from CLI-style options (or None if no auth)."""
+        hdrs = {}
+        for header in headers or []:
+            if ":" in header:
+                key, value = header.split(":", 1)
+                hdrs[key.strip()] = value.strip()
+        if basic:
+            token = base64.b64encode(basic.encode()).decode()
+            hdrs["Authorization"] = f"Basic {token}"
+        if bearer:
+            hdrs["Authorization"] = f"Bearer {bearer}"
+
+        data = {}
+        if login_data:
+            for pair in login_data.split("&"):
+                if "=" in pair:
+                    key, value = pair.split("=", 1)
+                    data[key] = value
+
+        if not (hdrs or login_url):
+            return None
+        return cls(headers=hdrs, login_url=login_url, login_data=data,
+                   csrf_field=csrf_field, logged_in_check=logged_in_check)
+
+    @property
+    def has_login(self):
+        return bool(self.login_url)
+
+    def _extract_csrf(self, session, verify, timeout):
+        """GET the login page and pull the hidden CSRF token, if configured."""
+        if not self.csrf_field:
+            return {}
+        try:
+            resp = session.get(self.login_url, verify=verify, timeout=timeout)
+        except Exception:
+            return {}
+        node = HTMLParser(resp.text).css_first(
+            f'input[name="{self.csrf_field}"]'
+        )
+        if node is not None:
+            return {self.csrf_field: node.attributes.get("value", "") or ""}
+        return {}
+
+    def login(self, session, verify=False, timeout=None):
+        """Perform the form login through the session (stores cookies)."""
+        if not self.has_login:
+            return None
+        # Serialize concurrent logins (the attack phase is multi-threaded).
+        with self._lock:
+            data = dict(self.login_data)
+            data.update(self._extract_csrf(session, verify, timeout))
+            try:
+                return session.post(
+                    self.login_url, data=data, verify=verify,
+                    timeout=timeout, allow_redirects=True,
+                )
+            except Exception:
+                return None
+
+    def looks_logged_out(self, resp):
+        """True when a response suggests the session is no longer valid."""
+        if resp is None or not (self.has_login and self.logged_in_check):
+            return False
+        return self.logged_in_check not in resp.text

--- a/lib/request/request.py
+++ b/lib/request/request.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import urllib3
 from requests import ConnectionError, Request, RequestException, Session, Timeout
 from requests.adapters import HTTPAdapter
+from requests.utils import dict_from_cookiejar
 
 from lib.utils.container import Services
 from . import ragent as ragent
@@ -30,6 +31,8 @@ class SingleRequest:
         self.random_agent = random_agent
         self.verify = verify
         self.ruagent = ragent.RandomUserAgent()
+        # Optional authentication context (headers + a shared cookie jar).
+        self.authenticator = None
 
         # Reuse one pooled session (keep-alive) across every request instead of
         # opening a fresh TCP/TLS connection per call.
@@ -40,17 +43,36 @@ class SingleRequest:
         if not self.verify:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    def send(self, url, method="GET", payload=None, headers=None, cookies=None):
+    def set_authenticator(self, authenticator):
+        self.authenticator = authenticator
+
+    def login(self):
+        """Run the configured login flow, populating the session cookie jar."""
+        if self.authenticator is not None and self.authenticator.has_login:
+            return self.authenticator.login(self.session, self.verify, self.timeout)
+        return None
+
+    def send(self, url, method="GET", payload=None, headers=None, cookies=None,
+             _retry=True):
         output = Services.get("output")
         prepped = self.prepare_request(url, method, payload, headers, cookies)
         try:
-            return self.session.send(
+            resp = self.session.send(
                 prepped,
                 timeout=self.timeout,
                 proxies={"http": self.proxy, "https": self.proxy, "ftp": self.proxy},
                 allow_redirects=self.redirect,
                 verify=self.verify,
             )
+            # If the session dropped (login page returned), re-authenticate once
+            # and retry so a mid-scan session expiry doesn't silently degrade to
+            # unauthenticated requests.
+            if _retry and self.authenticator is not None \
+                    and self.authenticator.looks_logged_out(resp):
+                self.authenticator.login(self.session, self.verify, self.timeout)
+                return self.send(url, method, payload, headers, cookies,
+                                 _retry=False)
+            return resp
         except Timeout:
             # requests raises requests.exceptions.Timeout (a RequestException),
             # not the builtin TimeoutError, so it must be caught explicitly.
@@ -65,9 +87,19 @@ class SingleRequest:
 
     def prepare_request(self, url, method, payload, headers, cookies):
         payload = payload or {}
-        headers = headers or {}
+        # Start from the authentication headers (e.g. Authorization) so every
+        # request carries them, then layer any per-call headers on top.
+        auth_headers = dict(self.authenticator.headers) if self.authenticator else {}
+        auth_headers.update(headers or {})
+        headers = auth_headers
+
+        # Merge the session cookie jar (populated at login) with any per-call
+        # cookie so authenticated sessions persist across requests.
+        jar = dict_from_cookiejar(self.session.cookies)
         if cookies is not None:
-            cookies = {cookies: ""}
+            jar[cookies] = ""
+        cookies = jar or None
+
         headers["User-Agent"] = (
             ragent.RandomUserAgent() if self.random_agent else self.agent
         )

--- a/sitadel.py
+++ b/sitadel.py
@@ -16,6 +16,7 @@ from lib.request.request import SingleRequest
 from lib.utils import banner, manager, output, validator
 from lib.utils.container import Services
 from lib.report import Findings, write_report
+from lib.request.auth import Authenticator
 from lib.utils.datastore import Datastore
 from lib.utils.logs import setup_logging
 from lib.utils.output import Output
@@ -86,6 +87,35 @@ class Sitadel(object):
             action="store_true",
             help="Verify the server's TLS certificate (off by default)",
         )
+        # Authentication options
+        parser.add_argument(
+            "--auth-basic", help="HTTP Basic credentials as user:password"
+        )
+        parser.add_argument(
+            "--auth-bearer", help="Bearer token to send in the Authorization header"
+        )
+        parser.add_argument(
+            "-H",
+            "--header",
+            dest="headers",
+            action="append",
+            help="Extra header 'Name: Value' (repeatable), e.g. an API key",
+        )
+        parser.add_argument(
+            "--login-url", help="URL to POST credentials to for form login"
+        )
+        parser.add_argument(
+            "--login-data",
+            help="Form login body, e.g. 'username=admin&password=secret'",
+        )
+        parser.add_argument(
+            "--csrf-field",
+            help="Name of a hidden CSRF field to read from the login page",
+        )
+        parser.add_argument(
+            "--logged-in-check",
+            help="String expected on authenticated pages (drives re-auth)",
+        )
         parser.add_argument(
             "-f", "--fingerprint", nargs="+", help="Fingerprint modules to activate"
         )
@@ -143,6 +173,31 @@ class Sitadel(object):
                 verify=args.verify,
             ),
         )
+
+        # Configure authentication (if any) and log in before scanning so all
+        # phases run as an authenticated user.
+        authenticator = Authenticator.from_options(
+            basic=args.auth_basic,
+            bearer=args.auth_bearer,
+            headers=args.headers,
+            login_url=args.login_url,
+            login_data=args.login_data,
+            csrf_field=args.csrf_field,
+            logged_in_check=args.logged_in_check,
+        )
+        if authenticator is not None:
+            request_factory = Services.get("request_factory")
+            request_factory.set_authenticator(authenticator)
+            if authenticator.has_login:
+                request_factory.login()
+                probe = request_factory.send(url=self.url, method="GET")
+                if authenticator.looks_logged_out(probe):
+                    Services.get("output").error(
+                        "Login may have failed: the 'logged-in' check did not "
+                        "match after authenticating."
+                    )
+                else:
+                    Services.get("output").info("Authenticated to the target.")
 
         # Display target and scan starting time
         self.bn.preamble(self.url)

--- a/tests/lib/request/test_auth.py
+++ b/tests/lib/request/test_auth.py
@@ -1,0 +1,160 @@
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import TCPServer, ThreadingMixIn
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from lib.request.auth import Authenticator
+from lib.request.request import SingleRequest
+from lib.utils.container import Services
+from lib.utils.output import Output
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests
+# --------------------------------------------------------------------------- #
+def test_from_options_builds_headers():
+    auth = Authenticator.from_options(basic="admin:secret")
+    if not auth.headers["Authorization"].startswith("Basic "):
+        raise AssertionError
+
+    auth = Authenticator.from_options(bearer="tok")
+    if auth.headers["Authorization"] != "Bearer tok":
+        raise AssertionError
+
+    auth = Authenticator.from_options(headers=["X-Api-Key: abc", "X-Env: test"])
+    if auth.headers["X-Api-Key"] != "abc" or auth.headers["X-Env"] != "test":
+        raise AssertionError
+
+    if Authenticator.from_options() is not None:
+        raise AssertionError  # no auth configured
+
+
+def test_singlerequest_merges_auth_header():
+    Services.register("output", Output())
+    req = SingleRequest()
+    req.set_authenticator(Authenticator.from_options(bearer="tok"))
+    prepped = req.prepare_request("http://example.com", "GET", None, None, None)
+    if prepped.headers.get("Authorization") != "Bearer tok":
+        raise AssertionError
+
+
+# --------------------------------------------------------------------------- #
+# Integration against a local login-protected site
+# --------------------------------------------------------------------------- #
+_VALID_TOKENS = set()
+
+
+class _Server(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+    def server_bind(self):
+        TCPServer.server_bind(self)
+        host, port = self.socket.getsockname()[:2]
+        self.server_name, self.server_port = host, port
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, body, code=200, cookie=None):
+        raw = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(raw)))
+        if cookie:
+            self.send_header("Set-Cookie", cookie)
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _session_ok(self):
+        cookie = self.headers.get("Cookie", "")
+        return any(
+            c.strip().startswith("session=") and c.strip().split("=", 1)[1] in _VALID_TOKENS
+            for c in cookie.split(";")
+        )
+
+    def do_GET(self):
+        path = urlsplit(self.path).path
+        if path == "/login":
+            self._send('<form><input name="csrf" value="tok123"></form>')
+        elif path == "/expire":
+            _VALID_TOKENS.clear()
+            self._send("expired")
+        elif path == "/home":
+            self._send("Welcome admin" if self._session_ok() else "Please login")
+        else:
+            self._send("root")
+
+    def do_POST(self):
+        if urlsplit(self.path).path == "/login":
+            length = int(self.headers.get("Content-Length", 0))
+            data = parse_qs(self.rfile.read(length).decode())
+            ok = (
+                data.get("user") == ["admin"]
+                and data.get("password") == ["secret"]
+                and data.get("csrf") == ["tok123"]
+            )
+            if ok:
+                token = f"t{len(_VALID_TOKENS)}x"
+                _VALID_TOKENS.add(token)
+                self._send("logged in", cookie=f"session={token}; Path=/")
+            else:
+                self._send("bad creds", code=403)
+        else:
+            self._send("nope", code=404)
+
+
+@pytest.fixture
+def login_site():
+    _VALID_TOKENS.clear()
+    server = _Server(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _authenticator(base):
+    return Authenticator.from_options(
+        login_url=f"{base}/login",
+        login_data="user=admin&password=secret",
+        csrf_field="csrf",
+        logged_in_check="Welcome",
+    )
+
+
+def test_form_login_reaches_protected_page(login_site):
+    Services.register("output", Output())
+    req = SingleRequest(timeout=5)
+    req.set_authenticator(_authenticator(login_site))
+    req.login()
+    resp = req.send(url=f"{login_site}/home")
+    if "Welcome admin" not in resp.text:
+        raise AssertionError
+
+    # Without authentication, the same page is not accessible.
+    anon = SingleRequest(timeout=5)
+    if "Welcome admin" in anon.send(url=f"{login_site}/home").text:
+        raise AssertionError
+
+
+def test_reauth_on_session_drop(login_site):
+    Services.register("output", Output())
+    req = SingleRequest(timeout=5)
+    req.set_authenticator(_authenticator(login_site))
+    req.login()
+    if "Welcome admin" not in req.send(url=f"{login_site}/home").text:
+        raise AssertionError
+
+    # Force the server to drop the session, then a normal request must detect
+    # the logged-out response, re-authenticate, and still succeed.
+    req.send(url=f"{login_site}/expire")
+    resp = req.send(url=f"{login_site}/home")
+    if "Welcome admin" not in resp.text:
+        raise AssertionError


### PR DESCRIPTION
Fixes #77.

## Problem
Sitadel could only pass a single cookie string (`-c`) and never authenticated — it only tested the **unauthenticated** surface. This is also the prerequisite for authorization testing (#78) and JWT testing (#82).

## Change (in the shared request layer — plugins unchanged)
- **`lib/request/auth.py` `Authenticator`**: HTTP Basic, static Bearer, arbitrary `-H` headers, and **form login with CSRF-token extraction** (selectolax, already a dep).
- **`SingleRequest`** carries the authenticator: merges auth headers + the **session cookie jar** into every request (it builds its own prepared requests, so cookies aren't auto-attached), and **re-authenticates + retries once** when a response looks logged out (mid-scan session expiry). Serialized with a lock for the multi-threaded attack phase.
- **CLI**: `--auth-basic`, `--auth-bearer`, `-H/--header`, `--login-url`, `--login-data`, `--csrf-field`, `--logged-in-check`. Login runs before the scan phases with a post-login verification.

## Verification
- `make test`: **43 passed** (added option-parsing, header-merge, a real form-login integration test against a local server, and an automatic-re-auth-on-session-drop test); `make criticalint`: clean.
- **End-to-end**: `sitadel <url> --login-url ... --login-data ... --csrf-field csrf --logged-in-check Welcome -f header` prints *"Authenticated to the target."* and then findings from the authenticated page.

## Notes
- Config-file `auth:` block and multi-identity sessions are follow-ups; multi-identity is added by #78 (which builds on this).
- No behaviour change when no `--auth-*`/`--login-*` is given (unauthenticated scans identical to before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)