### PR TITLE
Authenticate the async crawler so login-gated pages are discovered (#87)

### DIFF
--- a/lib/modules/crawler/crawler.py
+++ b/lib/modules/crawler/crawler.py
@@ -4,6 +4,7 @@ import asyncio
 from urllib.parse import parse_qsl, urljoin, urlsplit
 
 import aiohttp
+from requests.utils import dict_from_cookiejar
 from selectolax.parser import HTMLParser
 
 from lib.config import settings
@@ -23,6 +24,28 @@ def _config() -> dict:
     cfg = dict(_DEFAULTS)
     cfg.update(getattr(settings, "crawler", None) or {})
     return cfg
+
+
+def _auth_context():
+    """Auth headers + cookies to crawl as the authenticated user.
+
+    Read from the shared ``request_factory`` (populated by the login flow in
+    ``Authenticator``) so the crawler discovers pages behind login. Returns two
+    empty dicts when no request factory / authentication is configured, so
+    unauthenticated scans and direct ``crawl()`` calls are unaffected.
+    """
+    headers, cookies = {}, {}
+    try:
+        request = Services.get("request_factory")
+    except Exception:
+        return headers, cookies
+    authenticator = getattr(request, "authenticator", None)
+    if authenticator is not None:
+        headers.update(authenticator.headers)
+    session = getattr(request, "session", None)
+    if session is not None:
+        cookies.update(dict_from_cookiejar(session.cookies))
+    return headers, cookies
 
 
 def url_signature(url: str, ignore_params=()) -> tuple:
@@ -94,9 +117,14 @@ async def _crawl(start_url: str, user_agent: str, cfg: dict) -> list[str]:
     connector = aiohttp.TCPConnector(
         limit=concurrency, limit_per_host=concurrency, ssl=False
     )
-    headers = {"User-Agent": user_agent}
+    # Crawl as the authenticated user (same-domain restriction below keeps the
+    # cookies scoped to the target host).
+    extra_headers, cookies = _auth_context()
+    headers = {"User-Agent": user_agent, **extra_headers}
 
-    async with aiohttp.ClientSession(connector=connector, headers=headers) as session:
+    async with aiohttp.ClientSession(
+        connector=connector, headers=headers, cookies=cookies
+    ) as session:
 
         async def worker():
             while True:

--- a/tests/lib/modules/crawler/test_crawler.py
+++ b/tests/lib/modules/crawler/test_crawler.py
@@ -120,3 +120,94 @@ def test_crawl_respects_max_pages(local_site):
     results = crawl(local_site, "test-agent")
     if len(results) > 2:
         raise AssertionError(f"max_pages not respected: {len(results)} results")
+
+
+# ---------------------------------------------------------------------------
+# Authenticated crawling (issue #87)
+# ---------------------------------------------------------------------------
+class _AuthedFactory:
+    """Minimal stand-in for a logged-in request_factory."""
+
+    def __init__(self, cookies, headers):
+        import requests
+        self.session = requests.Session()
+        self.session.cookies.update(cookies)
+
+        class _Auth:
+            pass
+
+        self.authenticator = _Auth()
+        self.authenticator.headers = headers
+
+
+def test_auth_context_reads_request_factory():
+    from lib.modules.crawler.crawler import _auth_context
+
+    Services.register(
+        "request_factory",
+        _AuthedFactory({"session": "abc"}, {"Authorization": "Bearer tok"}),
+    )
+    try:
+        headers, cookies = _auth_context()
+        if headers.get("Authorization") != "Bearer tok":
+            raise AssertionError
+        if cookies.get("session") != "abc":
+            raise AssertionError
+    finally:
+        Services.services.pop("request_factory", None)
+
+
+class _AuthHandler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, body):
+        raw = body.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _authed(self):
+        return "session=valid" in self.headers.get("Cookie", "")
+
+    def do_GET(self):
+        # The link is only revealed to an authenticated session.
+        if urlsplit(self.path).path == "/":
+            if self._authed():
+                self._send('<a href="/secret?id=1">secret</a>')
+            else:
+                self._send("please login")
+        else:
+            self._send("leaf")
+
+
+@pytest.fixture
+def auth_site():
+    server = _Server(("127.0.0.1", 0), _AuthHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    host, port = server.server_address
+    Services.register("output", Output())
+    try:
+        yield f"http://{host}:{port}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+        Services.services.pop("request_factory", None)
+
+
+def test_authenticated_crawler_discovers_gated_links(auth_site):
+    Services.register(
+        "request_factory", _AuthedFactory({"session": "valid"}, {})
+    )
+    results = crawl(auth_site, "test-agent")
+    if not any("/secret?id=1" in u for u in results):
+        raise AssertionError("authenticated crawler should discover gated link")
+
+
+def test_unauthenticated_crawler_does_not_see_gated_links(auth_site):
+    Services.services.pop("request_factory", None)
+    results = crawl(auth_site, "test-agent")
+    if any("/secret" in u for u in results):
+        raise AssertionError("gated link must not be discovered without auth")


### PR DESCRIPTION
Fixes #87.

## Problem
Authentication (#77) covered the `request_factory` (fingerprint + attack phases) but **not the async crawler**, which used its own `aiohttp` session with only a `User-Agent`. On login-gated apps the crawler saw the unauthenticated site and never discovered pages behind login — under-covering the access-control checks (#78).

## Fix (crawler only; no signature / CLI / manager change)
- New `_auth_context()` reads the shared `request_factory` and returns the auth **headers** (`Authenticator.headers`) and **cookies** (`dict_from_cookiejar(session.cookies)`, populated at login before the crawl).
- The crawler's `aiohttp.ClientSession` is seeded with those headers/cookies. The existing same-domain restriction keeps cookies scoped to the target host.
- Guarded so a missing `request_factory` (tests / unauthenticated scans) is a **no-op** — behaviour unchanged without auth.

## Verification
- `make test`: **58 passed** (added `_auth_context` extraction + a gated-link crawl discovered *with* an authenticated session and *not* without); `make criticalint`: clean.
- **End-to-end payoff:** on a login-gated server where `/item?id=1` is only linked from the authenticated home page, the crawler now discovers it and the `authz` plugins report `Possible Broken Access Control` and `Possible IDOR` — the exact scenario that found nothing during #78.

## Notes
- Re-authentication *during* a long crawl (mid-crawl session expiry), crawler proxy support, and the legacy `-c/--cookie` path are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)