### PR TITLE
Fix empty sitadel.log; add progressive -v file logging (#89)

### DIFF
--- a/lib/request/request.py
+++ b/lib/request/request.py
@@ -56,6 +56,13 @@ class SingleRequest:
              _retry=True):
         output = Services.get("output")
         prepped = self.prepare_request(url, method, payload, headers, cookies)
+        # File-only trace of every request the scan makes. Since all attack
+        # modules send their probes through here, this records exactly which
+        # patterns/payloads were tested (visible in sitadel.log at -v).
+        output.trace(
+            "REQUEST %s %s%s"
+            % (method.upper(), url, f" data={payload}" if payload else "")
+        )
         try:
             resp = self.session.send(
                 prepped,

--- a/lib/utils/logs.py
+++ b/lib/utils/logs.py
@@ -1,40 +1,57 @@
 import logging
 
+# Progressive ``-v`` scale applied to the log file. Each extra ``-v`` lowers
+# the threshold one step, so more is written to ``sitadel.log``:
+#
+#   (no flag) -> ERROR    only errors
+#   -v        -> WARNING  warnings + errors
+#   -vv       -> INFO     progress + findings (+ above)
+#   -vvv      -> DEBUG    crawler paths + every tested pattern (+ above)
+#
+# ``-vvv`` and beyond all map to DEBUG (the most detailed level).
+_FILE_LEVELS = {
+    0: logging.ERROR,
+    1: logging.WARNING,
+    2: logging.INFO,
+}
+
+
+def verbosity_to_level(verbosity: int) -> int:
+    """Map a ``-v`` count to a :mod:`logging` level using the progressive scale."""
+    return _FILE_LEVELS.get(verbosity, logging.DEBUG)
+
 
 def setup_logging(verbosity=0, logfile="sitadel.log"):
-    """Configure and return the ``sitadelLog`` logger.
+    """Configure and return the ``sitadelLog`` logger (the file sink).
 
-    The file handler always records at INFO level so ``sitadel.log`` captures
-    the scan details (including the ERROR records emitted by the modules)
-    regardless of ``--verbosity``. ``--verbosity`` only controls how much is
-    echoed to the console. Previously the whole logger inherited the root
-    level set to ``CRITICAL`` by default, so nothing was ever written to the
-    file unless ``-v`` was passed (see issue #45).
+    The console is owned by :class:`lib.utils.output.Output`; this logger owns
+    the *file* only, so ``sitadel.log`` can hold strictly more detail than what
+    is echoed to stdout.
+
+    ``verbosity`` (the ``-v`` count) drives how much is written to the file via
+    the progressive scale in :data:`_FILE_LEVELS`: ``-v`` warnings, ``-vv``
+    info/findings, ``-vvv`` full debug (crawler paths and every payload/pattern
+    the attack modules test).
+
+    Previously the file handler was pinned to ``INFO`` and nothing in the
+    success path ever logged to it, so a clean run left ``sitadel.log`` empty
+    regardless of ``-v`` (see issue #45 and the follow-up on empty logs).
     """
     logger = logging.getLogger("sitadelLog")
     logger.setLevel(logging.DEBUG)
-    # Do not let records bubble up to the root logger (avoids duplicate output)
+    # Do not let records bubble up to the root logger (avoids duplicate output).
     logger.propagate = False
-    # Reset handlers so repeated calls don't stack duplicates
+    # Reset handlers so repeated calls don't stack duplicates.
     logger.handlers.clear()
 
-    # File handler: always capture the run details.
+    file_level = verbosity_to_level(verbosity)
     file_handler = logging.FileHandler(logfile, mode="w", encoding="utf-8")
-    file_handler.setLevel(logging.INFO)
+    file_handler.setLevel(file_level)
     file_handler.setFormatter(
         logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            "%(asctime)s - %(levelname)s - %(message)s",
             datefmt="%d-%b-%y %H:%M:%S",
         )
     )
-
-    # Console handler: driven by --verbosity, but errors stay visible by default.
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(min(logging.WARNING, logging.CRITICAL - (verbosity * 10)))
-    console_handler.setFormatter(
-        logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-    )
-
     logger.addHandler(file_handler)
-    logger.addHandler(console_handler)
     return logger

--- a/lib/utils/output.py
+++ b/lib/utils/output.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from colorama import Fore, Style
 
 from lib.report import Finding, Severity
@@ -15,11 +17,17 @@ class Output:
     e = Style.RESET_ALL
 
     def __init__(self, level: int = 0):
+        # ``level`` is the -v count; it gates how much reaches the console.
         self.level = level
+        # File logging is owned by the ``sitadelLog`` logger. Every console
+        # message is mirrored there, and ``trace`` adds file-only detail, so
+        # the log file is always a superset of stdout.
+        self.logger = logging.getLogger("sitadelLog")
 
     def finding(self, value: str, severity: Severity = Severity.INFO,
                 url: str | None = None, plugin: str | None = None) -> None:
         print(f"{self.g}[+]{self.e} {self.w}{value}{self.e}", flush=True)
+        self.logger.info("FINDING: %s", value)
         # Also record the finding for report generation, when a collector is
         # registered. Console output above is emitted unconditionally.
         try:
@@ -33,10 +41,26 @@ class Output:
 
     def error(self, value: str) -> None:
         print(f"{self.r}[-]{self.e} {self.w}{value}{self.e}", flush=True)
+        self.logger.error(value)
 
     def info(self, value: str) -> None:
         print(f"{self.y}[i]{self.e} {self.w}{value}{self.e}", flush=True)
+        self.logger.info(value)
 
     def debug(self, value: str) -> None:
-        if self.level == 1:
+        # Debug is the -vvv tier: printed to the console only at -vvv, but
+        # always forwarded to the file logger (which keeps it when the file
+        # handler is at DEBUG, i.e. also -vvv).
+        if self.level >= 3:
             print(f"{self.c}[d]{self.e} {self.w}{value}{self.e}", flush=True)
+        self.logger.debug(value)
+
+    def trace(self, value: str) -> None:
+        """File-only detail — never printed, even at high verbosity.
+
+        Used for the high-volume records that would drown the console but are
+        valuable in the log: every URL the crawler discovered and every
+        payload/pattern the attack modules test. These land in ``sitadel.log``
+        only when the file handler is at DEBUG (i.e. any ``-v``).
+        """
+        self.logger.debug(value)

--- a/sitadel.py
+++ b/sitadel.py
@@ -160,7 +160,7 @@ class Sitadel(object):
         # Register services
         Services.register("datastore", Datastore(settings.datastore))
         Services.register("logger", logger)
-        Services.register("output", Output())
+        Services.register("output", Output(args.verbosity))
         Services.register("findings", Findings())
         Services.register("profile", TargetProfile())
         Services.register(
@@ -218,6 +218,16 @@ class Sitadel(object):
 
             # Run the crawler to discover urls
             discovered_urls = self.ma.crawler(self.url, args.user_agent)
+
+            # Record the crawl surface. The count goes to console + file; the
+            # full list is file-only (-v) so the log lets you review every path
+            # discovered before any attack is launched, without flooding stdout.
+            output_svc = Services.get("output")
+            output_svc.info(
+                f"Crawler discovered {len(discovered_urls)} URL(s)"
+            )
+            for discovered in discovered_urls:
+                output_svc.trace(f"Crawled URL: {discovered}")
 
             # Hotfix on KeyboardInterrupt being redirected to scrapy crawler process
             signal.signal(signal.SIGINT, signal.default_int_handler)

--- a/tests/lib/utils/test_logs.py
+++ b/tests/lib/utils/test_logs.py
@@ -12,7 +12,8 @@ def _read(path):
 def test_file_captures_errors_by_default(tmp_path):
     logfile = os.path.join(str(tmp_path), "sitadel.log")
 
-    # Default verbosity (0): the file must still capture ERROR records.
+    # Default verbosity (0): the file is ERROR-only. Errors are captured;
+    # lower-severity records are dropped until -v raises the level.
     logger = setup_logging(verbosity=0, logfile=logfile)
     logger.error("boom-error")
     logger.info("some-info")
@@ -22,8 +23,8 @@ def test_file_captures_errors_by_default(tmp_path):
     content = _read(logfile)
     if "boom-error" not in content:
         raise AssertionError("ERROR records should be written to the log file")
-    if "some-info" not in content:
-        raise AssertionError("INFO records should be written to the log file")
+    if "some-info" in content:
+        raise AssertionError("INFO must be dropped from the file at -v0 (ERROR-only)")
 
 
 def test_logger_is_configured(tmp_path):
@@ -32,12 +33,57 @@ def test_logger_is_configured(tmp_path):
 
     if logger.name != "sitadelLog":
         raise AssertionError
-    # DEBUG at the logger level so handlers decide what to emit.
+    # DEBUG at the logger level so the handler decides what to emit.
     if logger.level != logging.DEBUG:
         raise AssertionError
-    # One file + one console handler, no duplicates on repeated setup.
+    # The logger owns the file only (the console is owned by Output); a single
+    # file handler, with no duplicates on repeated setup.
     setup_logging(verbosity=0, logfile=logfile)
-    if len(logger.handlers) != 2:
+    if len(logger.handlers) != 1:
         raise AssertionError
-    if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+    if not isinstance(logger.handlers[0], logging.FileHandler):
         raise AssertionError
+
+
+def test_verbosity_maps_to_progressive_file_level(tmp_path):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+
+    # The progressive -v scale: each extra -v lowers the file handler one step.
+    expected = {
+        0: logging.ERROR,
+        1: logging.WARNING,
+        2: logging.INFO,
+        3: logging.DEBUG,
+        4: logging.DEBUG,  # -vvvv and beyond stay at DEBUG
+    }
+    for verbosity, level in expected.items():
+        logger = setup_logging(verbosity=verbosity, logfile=logfile)
+        if logger.handlers[0].level != level:
+            raise AssertionError(
+                f"-v{verbosity} should map the file handler to {level}, "
+                f"got {logger.handlers[0].level}"
+            )
+
+
+def test_debug_detail_only_appears_at_vvv(tmp_path):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+
+    # -vv (INFO): info kept, DEBUG detail dropped.
+    logger = setup_logging(verbosity=2, logfile=logfile)
+    logger.info("kept-info")
+    logger.debug("quiet-debug")
+    for handler in logger.handlers:
+        handler.flush()
+    content = _read(logfile)
+    if "kept-info" not in content:
+        raise AssertionError("INFO must be kept in the file at -vv")
+    if "quiet-debug" in content:
+        raise AssertionError("DEBUG must be dropped from the file at -vv")
+
+    # -vvv (DEBUG): the detail is captured.
+    logger = setup_logging(verbosity=3, logfile=logfile)
+    logger.debug("loud-debug")
+    for handler in logger.handlers:
+        handler.flush()
+    if "loud-debug" not in _read(logfile):
+        raise AssertionError("DEBUG must be written to the file at -vvv")

--- a/tests/lib/utils/test_output.py
+++ b/tests/lib/utils/test_output.py
@@ -1,5 +1,8 @@
+import os
+
 from lib.report import Findings, Severity
 from lib.utils.container import Services
+from lib.utils.logs import setup_logging
 from lib.utils.output import Output
 
 
@@ -30,3 +33,48 @@ def test_finding_prints_and_records_when_collector_registered(capsys):
             raise AssertionError
     finally:
         Services.services.pop("findings", None)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_console_messages_are_mirrored_to_the_log_file(tmp_path, capsys):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+    # -vv puts the file at INFO so info() and finding() are captured.
+    logger = setup_logging(verbosity=2, logfile=logfile)
+    out = Output(level=2)
+
+    out.info("progress-line")
+    out.finding("a-finding")
+    out.error("an-error")
+    for handler in logger.handlers:
+        handler.flush()
+
+    content = _read(logfile)
+    # Everything printed to the console is also in the log file.
+    if "progress-line" not in content:
+        raise AssertionError("info() must be mirrored to the log file")
+    if "FINDING: a-finding" not in content:
+        raise AssertionError("finding() must be mirrored to the log file")
+    if "an-error" not in content:
+        raise AssertionError("error() must be mirrored to the log file")
+
+
+def test_trace_goes_to_file_only_never_console(tmp_path, capsys):
+    logfile = os.path.join(str(tmp_path), "sitadel.log")
+    # -vvv puts the file at DEBUG so trace() records are captured.
+    logger = setup_logging(verbosity=3, logfile=logfile)
+    # Even at high console verbosity, trace() must never print.
+    out = Output(level=99)
+
+    out.trace("tested-payload-xyz")
+    for handler in logger.handlers:
+        handler.flush()
+
+    captured = capsys.readouterr()
+    if "tested-payload-xyz" in captured.out:
+        raise AssertionError("trace() must never reach the console")
+    if "tested-payload-xyz" not in _read(logfile):
+        raise AssertionError("trace() must be written to the log file")


### PR DESCRIPTION
Fixes #89.

## Problem

`sitadel.log` was empty on a normal run — even with `-vvv`. All output went
through `Output.print()` (never the logger), the only records emitted were
exceptions, and the file handler was pinned to `INFO` while `-v` only affected
the console. A clean run wrote nothing.

## Change

The `sitadelLog` logger now owns the **file only**; `Output` owns the console
and **mirrors** every message to the logger, plus a file-only `trace()` for the
high-volume detail. The file handler level follows a **progressive `-v` scale**:

| flag | file level | contents |
|------|-----------|----------|
| (none) | `ERROR` | errors only |
| `-v` | `WARNING` | warnings + errors |
| `-vv` | `INFO` | progress + findings |
| `-vvv` | `DEBUG` | crawler paths + every payload/pattern tested |

- `Output(args.verbosity)` so the debug tier works; `debug()` prints to console
  only at `-vvv`, `trace()` never prints.
- Every request is traced in `SingleRequest.send` — all attack probes flow
  through it, so the log records exactly which patterns each attack tested.
- The crawl surface is dumped after crawling, so at `-vvv` you can review every
  discovered path before attacks launch.
- The log is always a superset of stdout for a given tier; console findings stay
  visible by default (unchanged UX).

## Files

- `lib/utils/logs.py` — progressive `verbosity_to_level()` map; file-only handler.
- `lib/utils/output.py` — mirror to logger + `trace()`; debug gated at `-vvv`.
- `lib/request/request.py` — per-request trace of method/url/payload.
- `sitadel.py` — `Output(args.verbosity)`; log crawl count + per-URL trace.
- `tests/lib/utils/test_logs.py`, `test_output.py` — progressive-tier, mirror,
  and file-only-trace regression tests.

## Verification

- `make test` → **59 passed** (new tests for the progressive scale, console
  mirroring, and file-only trace).
- `make criticalint` → clean.
- End-to-end on `http://www.example.com`:
  - `-vv` → `sitadel.log` populated with progress + findings (was 0 bytes).
  - `-vvv` → full DEBUG: every crawled URL and every tested request (`REQUEST
    HEAD /admin`, injection payloads, …).
  - default / `-v` → ERROR/WARNING only (quiet unless something is wrong).

## Note

By design, a clean default run now logs nothing (ERROR-only) — use `-vv` for a
findings audit trail or `-vvv` for the full request-level detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SYsRreT8X6VC2zNbMU9aF
