### PR TITLE
Finding quality: dedup, confidence, evidence, remediation, OWASP/CWE/WSTG mapping (#81)

### DIFF
--- a/sitadel/modules/attacks/__init__.py
+++ b/sitadel/modules/attacks/__init__.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import pkgutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import parse_qsl, urlsplit
 
 from sitadel.config import settings
 from sitadel.config.settings import Risk
@@ -100,11 +101,21 @@ class AttackPlugin(metaclass=IPlugin):
                     return
                 label = detector(resp, payload)
                 if label:
+                    # Record which field carried the payload so the report (and
+                    # its de-duplication) can tell apart issues on one endpoint:
+                    # the body fields for a JSON/XML/form target, else the query
+                    # parameters taint_url rewrote.
+                    if target.body_format:
+                        parameter = ",".join(target.params) or None
+                    else:
+                        parameter = self.tainted_params(target.url)
                     output.finding(
                         "That site may be vulnerable to %s at %s\nInjection: %s"
                         % (label, target.describe(), payload),
                         url=kwargs["url"],
                         plugin=type(self).__name__,
+                        parameter=parameter,
+                        evidence="payload=%s | matched=%s" % (payload, label),
                     )
             except Exception as err:
                 logger.error(err)
@@ -122,6 +133,17 @@ class AttackPlugin(metaclass=IPlugin):
             except KeyboardInterrupt:
                 executor.shutdown(False)
                 raise
+
+    @staticmethod
+    def tainted_params(url):
+        """Comma-joined names of the query parameters ``taint_url`` injects.
+
+        Recorded on findings as the ``parameter`` field so the report (and its
+        de-duplication) can distinguish issues on the same endpoint. Returns
+        ``None`` when the URL carries no query parameters.
+        """
+        params = dict(parse_qsl(urlsplit(url).query))
+        return ", ".join(params) if params else None
 
     def process(self, start_url, crawled_urls):
         raise NotImplementedError(str(self) + ": Process method not found")

--- a/sitadel/report/__init__.py
+++ b/sitadel/report/__init__.py
@@ -1,3 +1,4 @@
+from .knowledge import KNOWLEDGE, lookup
 from .report import (
     Finding,
     Findings,
@@ -12,6 +13,8 @@ __all__ = [
     "Finding",
     "Findings",
     "Severity",
+    "KNOWLEDGE",
+    "lookup",
     "to_html",
     "to_json",
     "to_sarif",

--- a/sitadel/report/knowledge.py
+++ b/sitadel/report/knowledge.py
@@ -1,0 +1,166 @@
+"""Remediation and standards knowledge base for findings.
+
+A small, data-only table keyed by *finding type* (the attack plugin's name,
+lowercased). Each entry supplies sane defaults for a finding's severity,
+confidence, and the standards mapping (CWE, OWASP Top-10, OWASP WSTG) plus
+remediation guidance. The output bridge (``lib/utils/output.py``) uses this to
+enrich findings *incrementally*: any field a plugin passes explicitly wins;
+anything it omits is filled from here so existing single-string
+``output.finding("text")`` calls still gain severity and context for free.
+
+Keys are matched case-insensitively. Lookup also tolerates a plugin
+``__repr__`` such as ``Injection`` (the package name) by falling back to a
+substring scan, so enrichment degrades gracefully rather than failing when a
+plugin reports under a coarse label.
+"""
+
+from __future__ import annotations
+
+from sitadel.report.report import Severity
+
+# finding-type -> defaults. Only include keys that add value; everything else
+# falls through to ``_DEFAULT``.
+KNOWLEDGE: dict[str, dict] = {
+    "sql": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-89",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-05",
+        "remediation": (
+            "Use parameterized queries / prepared statements and an ORM; never "
+            "concatenate user input into SQL. Apply least-privilege database "
+            "accounts and validate/whitelist input."
+        ),
+    },
+    "xss": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-79",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-01",
+        "remediation": (
+            "Context-aware output encoding on all reflected/stored data, a "
+            "restrictive Content-Security-Policy, and framework auto-escaping. "
+            "Validate input and avoid injecting untrusted data into the DOM."
+        ),
+    },
+    "html": {
+        "severity": Severity.MEDIUM,
+        "confidence": "tentative",
+        "cwe": "CWE-79",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-CLNT-03",
+        "remediation": (
+            "Encode user input before rendering it as HTML and sanitize markup "
+            "with an allow-list to prevent HTML injection."
+        ),
+    },
+    "php": {
+        "severity": Severity.CRITICAL,
+        "confidence": "firm",
+        "cwe": "CWE-94",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-11",
+        "remediation": (
+            "Never pass user input to eval()/include with dynamic paths. Disable "
+            "dangerous functions and validate input against a strict allow-list."
+        ),
+    },
+    "rfi": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-98",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-11",
+        "remediation": (
+            "Disable remote file inclusion (allow_url_include=Off), avoid "
+            "user-controlled include paths, and use an allow-list of local "
+            "resources."
+        ),
+    },
+    "ldap": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-90",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-06",
+        "remediation": (
+            "Escape LDAP special characters, use parameterized LDAP APIs, and "
+            "validate input before building distinguished names or filters."
+        ),
+    },
+    "xpath": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-643",
+        "owasp": "A03:2021-Injection",
+        "wstg": "WSTG-INPV-09",
+        "remediation": (
+            "Use parameterized XPath queries and escape/validate user input "
+            "before embedding it in XPath expressions."
+        ),
+    },
+    "idor": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-639",
+        "owasp": "A01:2021-Broken Access Control",
+        "wstg": "WSTG-ATHZ-04",
+        "remediation": (
+            "Enforce object-level authorization on every request; verify the "
+            "authenticated user owns or may access the referenced object. Use "
+            "unpredictable identifiers as defence in depth, not as the control."
+        ),
+    },
+    "access_control": {
+        "severity": Severity.HIGH,
+        "confidence": "firm",
+        "cwe": "CWE-284",
+        "owasp": "A01:2021-Broken Access Control",
+        "wstg": "WSTG-ATHZ-02",
+        "remediation": (
+            "Enforce access control server-side by default-deny; check function- "
+            "and object-level permissions on every protected route."
+        ),
+    },
+    "jwt": {
+        "severity": Severity.CRITICAL,
+        "confidence": "firm",
+        "cwe": "CWE-347",
+        "owasp": "A07:2021-Identification and Authentication Failures",
+        "wstg": "WSTG-SESS-10",
+        "remediation": (
+            "Reject 'alg':'none', pin the expected signing algorithm server-side, "
+            "verify signatures with the correct key type, enforce exp/nbf/iss/aud, "
+            "and use a strong random secret for HMAC."
+        ),
+    },
+}
+
+_DEFAULT: dict = {
+    "severity": Severity.INFO,
+    "confidence": "tentative",
+    "cwe": None,
+    "owasp": None,
+    "wstg": None,
+    "remediation": None,
+}
+
+
+def lookup(finding_type: str | None) -> dict:
+    """Return the knowledge entry for ``finding_type`` (or defaults).
+
+    Matching is case-insensitive and tolerant: an exact key wins; otherwise a
+    known key contained in the token (e.g. ``"Sql"`` inside ``"sql injection"``)
+    is used. Unknown types get the neutral default.
+    """
+    if not finding_type:
+        return dict(_DEFAULT)
+    key = str(finding_type).strip().lower()
+    if key in KNOWLEDGE:
+        return dict(KNOWLEDGE[key])
+    for known, entry in KNOWLEDGE.items():
+        if known in key:
+            return dict(entry)
+    return dict(_DEFAULT)

--- a/sitadel/report/report.py
+++ b/sitadel/report/report.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import html as _html
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
+from urllib.parse import urlsplit, urlunsplit
 
 
 class Severity(str, Enum):
@@ -16,7 +17,16 @@ class Severity(str, Enum):
 
 @dataclass
 class Finding:
-    """A single scan finding reported by a plugin."""
+    """A single scan finding reported by a plugin.
+
+    Beyond the core ``title``/``severity``/``url``, findings carry triage
+    metadata: ``confidence`` (how sure the detection is), captured
+    ``evidence`` (payload + matched marker), a standards mapping
+    (``cwe``/``owasp``/``wstg``), ``remediation`` guidance, and an
+    ``occurrences`` count maintained by :class:`Findings` when the same issue
+    is reported for many URLs. Every field except ``title`` is optional so
+    plugins can enrich incrementally.
+    """
 
     title: str
     severity: Severity = Severity.INFO
@@ -26,15 +36,61 @@ class Finding:
     confidence: str | None = None
     plugin: str | None = None
     cwe: str | None = None
+    owasp: str | None = None
+    wstg: str | None = None
+    remediation: str | None = None
+    occurrences: int = 1
+    # Extra URLs (beyond ``url``) where the same de-duplicated issue was seen.
+    other_urls: list[str] = field(default_factory=list)
+
+
+def _normalize_url(url: str | None) -> str:
+    """Collapse a URL to scheme+host+path (drop query/fragment).
+
+    Dedup treats ``/item?id=1`` and ``/item?id=2`` as the same endpoint so the
+    same issue crawled across many parameter values reports once. The injected
+    ``parameter`` still distinguishes findings on the same path.
+    """
+    if not url:
+        return ""
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _signature(finding: Finding) -> tuple[str, str, str]:
+    """Stable dedup key: (type, normalized-url, parameter).
+
+    ``type`` prefers the plugin name (stable per attack class) and falls back
+    to the title so findings without a plugin still de-duplicate sanely.
+    """
+    ftype = (finding.plugin or finding.title or "").strip().lower()
+    return (ftype, _normalize_url(finding.url), (finding.parameter or ""))
 
 
 class Findings:
-    """Collector for findings, registered in the Services container."""
+    """Collector for findings, registered in the Services container.
+
+    De-duplicates on insert: repeats of the same (type, endpoint, parameter)
+    collapse into the first finding with an incremented ``occurrences`` count,
+    so the same issue across 50 crawled URLs is one entry, not 50.
+    """
 
     def __init__(self):
         self._items: list[Finding] = []
+        self._index: dict[tuple[str, str, str], Finding] = {}
 
     def add(self, finding: Finding) -> None:
+        sig = _signature(finding)
+        existing = self._index.get(sig)
+        if existing is not None:
+            existing.occurrences += 1
+            # Keep a bounded trail of the distinct URLs the issue was seen on.
+            is_new_url = bool(finding.url) and finding.url != existing.url
+            if is_new_url and finding.url not in existing.other_urls:
+                if len(existing.other_urls) < 20:
+                    existing.other_urls.append(finding.url)
+            return
+        self._index[sig] = finding
         self._items.append(finding)
 
     def all(self) -> list[Finding]:
@@ -70,13 +126,44 @@ _SARIF_LEVEL = {
 
 def to_sarif(findings: list[Finding]) -> str:
     results = []
+    rules: dict[str, dict] = {}
     for f in findings:
         severity = f.severity if isinstance(f.severity, Severity) else Severity.INFO
+        rule_id = f.plugin or f.title
+
+        # Register one rule per rule_id, carrying remediation + standards.
+        if rule_id not in rules:
+            rule: dict = {"id": rule_id, "name": rule_id}
+            if f.remediation:
+                rule["help"] = {"text": f.remediation}
+            props = {}
+            if f.cwe:
+                props["cwe"] = f.cwe
+            if f.owasp:
+                props["owasp"] = f.owasp
+            if f.wstg:
+                props["wstg"] = f.wstg
+            tags = [t for t in (f.cwe, f.owasp, f.wstg) if t]
+            if tags:
+                props["tags"] = tags
+            if props:
+                rule["properties"] = props
+            rules[rule_id] = rule
+
         result = {
-            "ruleId": f.plugin or f.title,
+            "ruleId": rule_id,
             "level": _SARIF_LEVEL.get(severity, "note"),
             "message": {"text": f.title},
         }
+        props = {}
+        if f.confidence:
+            props["confidence"] = f.confidence
+        if f.occurrences and f.occurrences > 1:
+            props["occurrences"] = f.occurrences
+        if f.evidence:
+            props["evidence"] = f.evidence
+        if props:
+            result["properties"] = props
         if f.url:
             result["locations"] = [
                 {"physicalLocation": {"artifactLocation": {"uri": f.url}}}
@@ -86,33 +173,61 @@ def to_sarif(findings: list[Finding]) -> str:
         "version": "2.1.0",
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
         "runs": [
-            {"tool": {"driver": {"name": "Sitadel"}}, "results": results}
+            {
+                "tool": {
+                    "driver": {"name": "Sitadel", "rules": list(rules.values())}
+                },
+                "results": results,
+            }
         ],
     }
     return json.dumps(doc, indent=2)
+
+
+def _std_cell(finding: Finding) -> str:
+    parts = [p for p in (finding.cwe, finding.owasp, finding.wstg) if p]
+    return _html.escape(" / ".join(parts))
 
 
 def to_html(findings: list[Finding]) -> str:
     rows = []
     for f in findings:
         severity = f.severity.value if isinstance(f.severity, Severity) else f.severity
+        occ = str(f.occurrences) if f.occurrences and f.occurrences > 1 else ""
         cells = [
             _html.escape(severity or ""),
+            _html.escape(f.confidence or ""),
             _html.escape(f.title or ""),
             _html.escape(f.url or ""),
+            _html.escape(f.parameter or ""),
+            occ,
             _html.escape(f.evidence or ""),
+            _std_cell(f),
+            _html.escape(f.remediation or ""),
         ]
-        rows.append("<tr>" + "".join(f"<td>{c}</td>" for c in cells) + "</tr>")
-    body = "\n".join(rows) or '<tr><td colspan="4">No findings</td></tr>'
+        sev_class = f"sev-{severity}" if severity else ""
+        rows.append(
+            f'<tr class="{sev_class}">'
+            + "".join(f"<td>{c}</td>" for c in cells)
+            + "</tr>"
+        )
+    body = "\n".join(rows) or '<tr><td colspan="9">No findings</td></tr>'
     return (
         "<!doctype html><html><head><meta charset='utf-8'>"
         "<title>Sitadel report</title>"
         "<style>body{font-family:sans-serif}table{border-collapse:collapse;width:100%}"
-        "th,td{border:1px solid #ccc;padding:6px;text-align:left}"
-        "th{background:#222;color:#fff}</style></head><body>"
+        "th,td{border:1px solid #ccc;padding:6px;text-align:left;vertical-align:top}"
+        "th{background:#222;color:#fff}"
+        ".sev-critical td:first-child{background:#b60205;color:#fff}"
+        ".sev-high td:first-child{background:#d93f0b;color:#fff}"
+        ".sev-medium td:first-child{background:#fbca04}"
+        ".sev-low td:first-child{background:#c2e0c6}"
+        "</style></head><body>"
         f"<h1>Sitadel report</h1><p>{len(findings)} finding(s)</p>"
-        "<table><thead><tr><th>Severity</th><th>Title</th><th>URL</th>"
-        f"<th>Evidence</th></tr></thead><tbody>{body}</tbody></table>"
+        "<table><thead><tr><th>Severity</th><th>Confidence</th><th>Title</th>"
+        "<th>URL</th><th>Parameter</th><th>Count</th><th>Evidence</th>"
+        "<th>CWE / OWASP / WSTG</th><th>Remediation</th></tr></thead>"
+        f"<tbody>{body}</tbody></table>"
         "</body></html>"
     )
 

--- a/sitadel/utils/output.py
+++ b/sitadel/utils/output.py
@@ -5,6 +5,7 @@ import logging
 from colorama import Fore, Style
 
 from sitadel.report import Finding, Severity
+from sitadel.report.knowledge import lookup as _lookup_knowledge
 from sitadel.utils.container import Services
 
 
@@ -24,8 +25,21 @@ class Output:
         # the log file is always a superset of stdout.
         self.logger = logging.getLogger("sitadelLog")
 
-    def finding(self, value: str, severity: Severity = Severity.INFO,
-                url: str | None = None, plugin: str | None = None) -> None:
+    def finding(self, value: str, severity: Severity | None = None,
+                url: str | None = None, plugin: str | None = None,
+                parameter: str | None = None, evidence: str | None = None,
+                confidence: str | None = None, cwe: str | None = None,
+                owasp: str | None = None, wstg: str | None = None,
+                remediation: str | None = None,
+                finding_type: str | None = None) -> None:
+        r"""Report a finding: print it, log it, and record it for the report.
+
+        Only ``value`` is required, so legacy ``finding("text")`` calls keep
+        working. Any triage field a plugin omits is filled from the
+        remediation/standards knowledge base (keyed by ``finding_type`` or the
+        ``plugin`` name), so even single-string findings gain a sane severity,
+        confidence, and CWE/OWASP/WSTG mapping. Explicit arguments always win.
+        """
         print(f"{self.g}[+]{self.e} {self.w}{value}{self.e}", flush=True)
         self.logger.info("FINDING: %s", value)
         # Also record the finding for report generation, when a collector is
@@ -35,8 +49,25 @@ class Output:
         except NameError:
             collector = None
         if collector is not None:
+            kb = _lookup_knowledge(finding_type or plugin)
+
+            def pick(explicit, key):
+                return explicit if explicit is not None else kb.get(key)
+
             collector.add(
-                Finding(title=value, severity=severity, url=url, plugin=plugin)
+                Finding(
+                    title=value,
+                    severity=pick(severity, "severity") or Severity.INFO,
+                    url=url,
+                    parameter=parameter,
+                    evidence=evidence,
+                    confidence=pick(confidence, "confidence"),
+                    plugin=plugin,
+                    cwe=pick(cwe, "cwe"),
+                    owasp=pick(owasp, "owasp"),
+                    wstg=pick(wstg, "wstg"),
+                    remediation=pick(remediation, "remediation"),
+                )
             )
 
     def error(self, value: str) -> None:

--- a/tests/sitadel/report/test_knowledge.py
+++ b/tests/sitadel/report/test_knowledge.py
@@ -1,0 +1,40 @@
+from sitadel.report import Severity
+from sitadel.report.knowledge import lookup
+
+
+def test_lookup_exact_key():
+    entry = lookup("sql")
+    if entry["severity"] != Severity.HIGH or entry["cwe"] != "CWE-89":
+        raise AssertionError
+
+
+def test_lookup_is_case_insensitive():
+    if lookup("SQL")["cwe"] != lookup("sql")["cwe"]:
+        raise AssertionError
+
+
+def test_lookup_substring_fallback():
+    # A coarse label containing a known key still resolves.
+    entry = lookup("sql injection")
+    if entry["cwe"] != "CWE-89":
+        raise AssertionError
+
+
+def test_lookup_unknown_returns_neutral_default():
+    entry = lookup("totally-unknown-type")
+    if entry["severity"] != Severity.INFO or entry["cwe"] is not None:
+        raise AssertionError
+
+
+def test_lookup_none():
+    entry = lookup(None)
+    if entry["severity"] != Severity.INFO:
+        raise AssertionError
+
+
+def test_lookup_returns_a_copy():
+    # Mutating a returned entry must not corrupt the shared table.
+    entry = lookup("sql")
+    entry["cwe"] = "mutated"
+    if lookup("sql")["cwe"] != "CWE-89":
+        raise AssertionError

--- a/tests/sitadel/report/test_report.py
+++ b/tests/sitadel/report/test_report.py
@@ -63,3 +63,77 @@ def test_write_report(tmp_path):
         data = json.load(fh)
     if len(data) != 2:
         raise AssertionError
+
+
+def test_dedup_collapses_same_issue_across_urls():
+    coll = Findings()
+    # Same plugin + endpoint + parameter, only the query value differs: one
+    # finding with an occurrence count, plus the extra URLs recorded.
+    for i in range(5):
+        coll.add(Finding(title="SQLi", plugin="Sql", parameter="id",
+                         url=f"http://host/item?id={i}"))
+    if len(coll) != 1:
+        raise AssertionError("repeats must collapse to a single finding")
+    item = coll.all()[0]
+    if item.occurrences != 5:
+        raise AssertionError("occurrences must count every repeat")
+    if item.url != "http://host/item?id=0":
+        raise AssertionError("first seen URL is kept as representative")
+    if len(item.other_urls) != 4:
+        raise AssertionError("distinct extra URLs must be recorded")
+
+
+def test_dedup_keeps_distinct_types_and_params_separate():
+    coll = Findings()
+    coll.add(Finding(title="SQLi", plugin="Sql", parameter="id",
+                     url="http://host/item?id=1"))
+    coll.add(Finding(title="SQLi", plugin="Sql", parameter="name",
+                     url="http://host/item?name=x"))  # different param
+    coll.add(Finding(title="XSS", plugin="Xss", parameter="id",
+                     url="http://host/item?id=1"))     # different type
+    coll.add(Finding(title="SQLi", plugin="Sql", parameter="id",
+                     url="http://host/other?id=1"))    # different endpoint
+    if len(coll) != 4:
+        raise AssertionError("distinct type/param/endpoint must not collapse")
+
+
+def test_json_serializes_enriched_fields():
+    f = Finding(title="SQLi", severity=Severity.HIGH, plugin="Sql",
+                cwe="CWE-89", owasp="A03:2021-Injection", wstg="WSTG-INPV-05",
+                remediation="Use prepared statements", occurrences=3)
+    data = json.loads(to_json([f]))[0]
+    for key in ("cwe", "owasp", "wstg", "remediation", "occurrences",
+                "confidence", "parameter"):
+        if key not in data:
+            raise AssertionError(f"{key} must be serialized")
+    if data["occurrences"] != 3 or data["cwe"] != "CWE-89":
+        raise AssertionError
+
+
+def test_sarif_carries_rule_help_and_standards():
+    f = Finding(title="SQLi", severity=Severity.HIGH, plugin="Sql",
+                url="http://host/x", cwe="CWE-89",
+                owasp="A03:2021-Injection", wstg="WSTG-INPV-05",
+                remediation="Use prepared statements")
+    doc = json.loads(to_sarif([f]))
+    driver = doc["runs"][0]["tool"]["driver"]
+    rules = driver["rules"]
+    if not rules or rules[0]["id"] != "Sql":
+        raise AssertionError("a rule must be registered per rule id")
+    if rules[0]["help"]["text"] != "Use prepared statements":
+        raise AssertionError("remediation must land in rule.help")
+    if "CWE-89" not in rules[0]["properties"]["tags"]:
+        raise AssertionError("standards must be exposed as rule tags")
+    result = doc["runs"][0]["results"][0]
+    if result["level"] != "error":  # high -> error
+        raise AssertionError
+
+
+def test_html_shows_evidence_remediation_and_count():
+    f = Finding(title="SQLi", severity=Severity.HIGH, url="http://host/x",
+                evidence="MySQL syntax error", remediation="Use prepared statements",
+                cwe="CWE-89", occurrences=7)
+    out = to_html([f])
+    for needle in ("MySQL syntax error", "Use prepared statements", "CWE-89", "7"):
+        if needle not in out:
+            raise AssertionError(f"HTML must show {needle!r}")

--- a/tests/sitadel/utils/test_output.py
+++ b/tests/sitadel/utils/test_output.py
@@ -35,6 +35,53 @@ def test_finding_prints_and_records_when_collector_registered(capsys):
         Services.services.pop("findings", None)
 
 
+def test_finding_is_enriched_from_knowledge_base_by_plugin(capsys):
+    collector = Findings()
+    Services.register("findings", collector)
+    try:
+        # Legacy-style single-string call, but with the plugin name: the KB
+        # fills severity/cwe/owasp/wstg/remediation for free.
+        Output().finding("SQL injection at /x", plugin="Sql")
+        item = collector.all()[0]
+        if item.severity != Severity.HIGH:
+            raise AssertionError("severity must come from the KB")
+        if item.cwe != "CWE-89" or item.owasp != "A03:2021-Injection":
+            raise AssertionError("standards mapping must be filled from the KB")
+        if not item.remediation:
+            raise AssertionError("remediation must be filled from the KB")
+    finally:
+        Services.services.pop("findings", None)
+
+
+def test_explicit_finding_args_override_knowledge_base(capsys):
+    collector = Findings()
+    Services.register("findings", collector)
+    try:
+        Output().finding("SQLi", plugin="Sql", severity=Severity.CRITICAL,
+                         cwe="CWE-000", evidence="marker", parameter="id",
+                         confidence="firm")
+        item = collector.all()[0]
+        if item.severity != Severity.CRITICAL or item.cwe != "CWE-000":
+            raise AssertionError("explicit args must win over the KB")
+        if item.evidence != "marker" or item.parameter != "id":
+            raise AssertionError("evidence/parameter must be recorded")
+    finally:
+        Services.services.pop("findings", None)
+
+
+def test_legacy_finding_without_plugin_still_records(capsys):
+    collector = Findings()
+    Services.register("findings", collector)
+    try:
+        # Unknown type: neutral defaults, no crash, still recorded.
+        Output().finding("something happened")
+        item = collector.all()[0]
+        if item.title != "something happened" or item.severity != Severity.INFO:
+            raise AssertionError
+    finally:
+        Services.services.pop("findings", None)
+
+
 def _read(path):
     with open(path, encoding="utf-8") as fh:
         return fh.read()


### PR DESCRIPTION
Closes #81.

## Summary
#69 gave us a findings store + JSON/HTML/SARIF output, but findings were flat strings at default `info` severity, duplicated once per crawled URL, with no triage metadata. This PR raises them to pen-test grade: **de-duplication, confidence, evidence, remediation, and OWASP Top-10 / CWE / WSTG mapping** per finding — all backward compatible.

## What changed
- **Enriched `Finding`** (`lib/report/report.py`): added `owasp`, `wstg`, `remediation`, `occurrences`, and an `other_urls` trail on top of the existing `severity`/`evidence`/`confidence`/`cwe`.
- **Dedup in the `Findings` collector**: stable signature `(type, normalized endpoint, parameter)`. The same issue across many crawled URLs collapses into one finding with an occurrence count. Distinct types/params/endpoints stay separate. Producers stay dumb.
- **Remediation/standards KB** (`lib/report/knowledge.py`): a data-only table keyed by finding type → severity/confidence/CWE/OWASP/WSTG + remediation text. Case-insensitive with a tolerant substring fallback.
- **Widened the `output.finding()` bridge** (`lib/utils/output.py`): new `evidence`/`parameter`/`confidence`/`cwe`/`owasp`/`wstg`/`remediation`/`finding_type` kwargs that auto-enrich from the KB (keyed by `finding_type` or `plugin`). **Explicit args always win.** Legacy `output.finding("text")` calls are unchanged and now gain severity/context for free.
- **Reporters render the new fields**: SARIF gets a `rule` per rule-id with `help` (remediation) + standards `tags`, and `level` from severity; HTML shows confidence / parameter / count / evidence / standards / remediation with severity coloring; JSON serializes everything.
- **Incremental plugin adoption**: the SQL and XSS injection modules now pass `plugin`/`parameter`/`evidence` through the richer bridge (new `AttackPlugin.tainted_params()` helper).

## Acceptance criteria
- [x] The same issue across many URLs is reported once with an occurrence count.
- [x] Findings carry severity, confidence, evidence, CWE/OWASP/WSTG, and remediation; SARIF `level` reflects severity and HTML shows evidence + remediation.
- [x] Existing `output.finding("text")` calls still work unchanged.

## Tests
14 new tests (dedup collapse + separation, KB lookup semantics, bridge enrichment + override, reporter rendering). Full suite: **76 passed, 2 deselected**. `criticalint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tpi1SNZGWDqimtiwXanr64